### PR TITLE
Theme customizer constant prefix

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -10,7 +10,7 @@ define( 'UCFWP_THEME_JS_URL', UCFWP_THEME_STATIC_URL . '/js' );
 define( 'UCFWP_THEME_IMG_URL', UCFWP_THEME_STATIC_URL . '/img' );
 define( 'UCFWP_THEME_CUSTOMIZER_PREFIX', 'ucfwp_' );
 define( 'UCFWP_MAINSITE_NAV_URL', 'https://www.ucf.edu/wp-json/ucf-rest-menus/v1/menus/23' );
-define( 'THEME_CUSTOMIZER_DEFAULTS', serialize( array(
+define( 'UCFWP_THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 	'person_thumbnail' => UCFWP_THEME_STATIC_URL . '/img/person-no-photo.png'
 ) ) );
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -91,10 +91,10 @@ function ucfwp_fetch_json( $url ) {
 
 
 /**
- * Returns a theme mod value from THEME_CUSTOMIZER_DEFAULTS.
+ * Returns a theme mod value from UCFWP_THEME_CUSTOMIZER_DEFAULTS.
  **/
 function ucfwp_get_theme_mod_default( $theme_mod ) {
-	$defaults = unserialize( THEME_CUSTOMIZER_DEFAULTS );
+	$defaults = unserialize( UCFWP_THEME_CUSTOMIZER_DEFAULTS );
 	if ( $defaults && isset( $defaults[$theme_mod] ) ) {
 		return $defaults[$theme_mod];
 	}
@@ -103,8 +103,8 @@ function ucfwp_get_theme_mod_default( $theme_mod ) {
 
 
 /**
- * Returns a theme mod value or the default set in THEME_CUSTOMIZER_DEFAULTS if
- * the theme mod value hasn't been set yet.
+ * Returns a theme mod value or the default set in
+ * UCFWP_THEME_CUSTOMIZER_DEFAULTS if the theme mod value hasn't been set yet.
  **/
 function ucfwp_get_theme_mod_or_default( $theme_mod ) {
 	$mod = get_theme_mod( $theme_mod  );


### PR DESCRIPTION
Quick update that adds the 'UCFWP_' prefix to the `THEME_CUSTOMIZER_DEFAULTS` constant to prevent potential conflicts in child themes.