### PR TITLE
Enqueued CSS version number fix

### DIFF
--- a/includes/meta.php
+++ b/includes/meta.php
@@ -14,8 +14,8 @@ function ucfwp_enqueue_frontend_assets() {
 	}
 
 	// Register main theme stylesheet
-	$theme = wp_get_theme();
-	$theme_version = $theme->get( 'Version' );
+	$theme = wp_get_theme( 'UCF-WordPress-Theme' );
+	$theme_version = ( $theme instanceof WP_Theme ) ? $theme->get( 'Version' ) : false;
 
 	wp_enqueue_style( 'style', UCFWP_THEME_CSS_URL . '/style.min.css', null, $theme_version );
 


### PR DESCRIPTION
Fixed issue where enqueued theme css's version number would be enqueued with a child theme's version number if used as a parent theme.