### PR TITLE
Theme mod retrieval updates

### DIFF
--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -117,15 +117,8 @@ function ucfwp_get_theme_mod_default( $theme_mod, $defaults=UCFWP_THEME_CUSTOMIZ
  * @return mixed Theme mod value or its default
  **/
 function ucfwp_get_theme_mod_or_default( $theme_mod, $defaults=UCFWP_THEME_CUSTOMIZER_DEFAULTS ) {
-	$mod = get_theme_mod( $theme_mod );
 	$default = ucfwp_get_theme_mod_default( $theme_mod, $defaults );
-	// Only apply the default if an explicit theme mod value hasn't been set
-	// yet (e.g. immediately after theme activation). Otherwise, assume empty
-	// values are intentional.
-	if ( $mod === false && $default ) {
-		return $default;
-	}
-	return $mod;
+	return get_theme_mod( $theme_mod, $default );
 }
 
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -91,10 +91,15 @@ function ucfwp_fetch_json( $url ) {
 
 
 /**
- * Returns a theme mod value from UCFWP_THEME_CUSTOMIZER_DEFAULTS.
+ * Returns a theme mod's default value from a constant.
+ *
+ * @since 0.2.2
+ * @param string $theme_mod The name of the theme mod
+ * @param string $defaults Serialized array of theme mod names + default values
+ * @return mixed Theme mod default value, or false if a default is not set
  **/
-function ucfwp_get_theme_mod_default( $theme_mod ) {
-	$defaults = unserialize( UCFWP_THEME_CUSTOMIZER_DEFAULTS );
+function ucfwp_get_theme_mod_default( $theme_mod, $defaults=UCFWP_THEME_CUSTOMIZER_DEFAULTS ) {
+	$defaults = unserialize( $defaults );
 	if ( $defaults && isset( $defaults[$theme_mod] ) ) {
 		return $defaults[$theme_mod];
 	}
@@ -104,11 +109,16 @@ function ucfwp_get_theme_mod_default( $theme_mod ) {
 
 /**
  * Returns a theme mod value or the default set in
- * UCFWP_THEME_CUSTOMIZER_DEFAULTS if the theme mod value hasn't been set yet.
+ * $defaults if the theme mod value hasn't been set yet.
+ *
+ * @since 0.2.2
+ * @param string $theme_mod The name of the theme mod
+ * @param string $defaults Serialized array of theme mod names + default values
+ * @return mixed Theme mod value or its default
  **/
-function ucfwp_get_theme_mod_or_default( $theme_mod ) {
-	$mod = get_theme_mod( $theme_mod  );
-	$default = ucfwp_get_theme_mod_default( $theme_mod );
+function ucfwp_get_theme_mod_or_default( $theme_mod, $defaults=UCFWP_THEME_CUSTOMIZER_DEFAULTS ) {
+	$mod = get_theme_mod( $theme_mod );
+	$default = ucfwp_get_theme_mod_default( $theme_mod, $defaults );
 	// Only apply the default if an explicit theme mod value hasn't been set
 	// yet (e.g. immediately after theme activation). Otherwise, assume empty
 	// values are intentional.


### PR DESCRIPTION
- Updated theme mod retrieval functions to allow other defaults sets to be referenced (for child themes and their own customizer settings)
- Simplified `ucfwp_get_theme_mod_or_default()` by utilizing `get_theme_mod()`'s `$default` param.  `ucfwp_get_theme_mod_or_default()` should still function the same as it did previously.  `get_theme_mod()`'s logic can be reviewed here: https://core.trac.wordpress.org/browser/tags/4.9.8/src/wp-includes/theme.php#L854