### PR TITLE
More accurate header title text; made _before hooks useful

### DIFF
--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -23,7 +23,7 @@ function ucfwp_get_header_images( $obj ) {
 
 	$retval = (array) apply_filters( 'ucfwp_get_header_images_before', $retval, $obj );
 	// Exit early if this filter added a 'header_image' value
-	if ( isset( $retval['header_image'] ) && ! empty( $retval['header_image'] ) ) {
+	if ( isset( $retval['header_image'] ) && $retval['header_image'] ) {
 		return $retval;
 	}
 


### PR DESCRIPTION
- Updated logic in `ucfwp_get_header_title()` to more closely match how WordPress generates a page title in `wp_get_document_title()`.  Support for titles in templates that are disabled by default (e.g. author, date-based views) in `ucfwp_kill_unused_templates()` has been added in case a child theme re-enables a template.
- Added returns after `ucfwp_get_header_images_before`, `ucfwp_get_header_videos_before`, `ucfwp_get_header_title_before`, and `ucfwp_get_header_subtitle_before` to allow these hooks to properly short-circuit the rest of their containing functions when filters are provided.