### PR TITLE
Theme activation prerequisite checks

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,7 @@
 <?php
+// Activation checks
+include_once 'includes/activate.php';
+
 // Theme foundation
 include_once 'includes/utilities.php';
 include_once 'includes/config.php';

--- a/includes/activate.php
+++ b/includes/activate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * All pre- and post-theme activation steps should be registered in this file.
+ * All post-theme activation steps should be registered in this file.
  */
 
 

--- a/includes/activate.php
+++ b/includes/activate.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * All pre- and post-theme activation steps should be registered in this file.
+ */
+
+
+/**
+ * Prints an error message in the WordPress admin notifying the user
+ * that ACF PRO is a required plugin for this theme.
+ *
+ * @since 0.2.7
+ * @author Jo Dickson
+ */
+function ucfwp_activation_error_acf() {
+	ob_start();
+?>
+	<div class="notice notice-error">
+		<p><strong>Theme not activated:</strong> The UCF WordPress Theme requires the <a href="https://www.advancedcustomfields.com/pro/" target="_blank">Advanced Custom Fields PRO</a> plugin.  Please install and activate ACF PRO and try again.</p>
+	</div>
+<?php
+	echo ob_get_clean();
+}
+
+
+/**
+ * Performs verification checks immediately upon theme activation
+ * to ensure required dependencies are installed. Will revert to the
+ * previously-active theme if a requirement isn't met.
+ *
+ * @since 0.2.7
+ * @author Jo Dickson
+ * @param string $oldtheme_name The name of the theme that was active prior to switching to this theme
+ * @param object $oldtheme WP_Theme instance of the old theme.
+ */
+function ucfwp_activation_checks( $oldtheme_name, $oldtheme ) {
+	$do_revert = false;
+
+	// Require ACF PRO
+	if ( ! class_exists( 'acf_pro' ) ) {
+		$do_revert = true;
+		add_action( 'admin_notices', 'ucfwp_activation_error_acf' );
+	}
+
+	// Switch back to previous theme if a requirement is missing
+	if ( $do_revert ) {
+		switch_theme( $oldtheme->stylesheet );
+	}
+
+	return false;
+}
+
+add_action( 'after_switch_theme', 'ucfwp_activation_checks', 10, 2 );


### PR DESCRIPTION
Added post-theme activation logic to warn the user if ACF PRO isn't installed, and revert back to the last active theme.

We could potentially expand upon this in the future to allow child themes to register their own dependencies, or add other post-activation notices (e.g. to remind the user to import ACF fields groups).

Resolves #25.