### PR TITLE
Documentation-related updates

### DIFF
--- a/gulp-config.template.json
+++ b/gulp-config.template.json
@@ -1,4 +1,4 @@
 {
   "sync": false,
-  "syncTarget": "http://localhost/wordpress/main-site/"
+  "syncTarget": "http://localhost/wordpress/"
 }

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -50,7 +50,7 @@ function ucfwp_get_header_images( $obj ) {
  * @author Jo Dickson
  * @since 0.0.0
  * @param object $obj A WP_Post or WP_Term object
- * @return array A set of Attachment IDs corresponding to available video filetypes
+ * @return array A set of Attachment urls corresponding to available video filetypes
  **/
 function ucfwp_get_header_videos( $obj ) {
 	$obj_id = ucfwp_get_object_id( $obj );
@@ -399,7 +399,7 @@ if ( !function_exists( 'ucfwp_get_header_content_custom' ) ) {
  * @since 0.2.1
  * @param string $header_height Name of the header's height
  * @param array $images Assoc. array of image size names and attachment IDs (expects a return value from ucfwp_get_header_images())
- * @return array Assoc. array of breakpoint names and image URLs (see ucfwp_get_media_background_picture_srcs())
+ * @return array Assoc. array of breakpoint names and image urls (see ucfwp_get_media_background_picture_srcs())
  */
 if ( ! function_exists( 'ucfwp_get_header_media_picture_srcs' ) ) {
 	function ucfwp_get_header_media_picture_srcs( $header_height, $images ) {
@@ -431,7 +431,7 @@ if ( ! function_exists( 'ucfwp_get_header_media_picture_srcs' ) ) {
  * @author Jo Dickson
  * @since 0.0.0
  * @param object $obj A WP_Post or WP_Term object
- * @param array $videos Assoc. array of video Attachment IDs for use in page header media background
+ * @param array $videos Assoc. array of video Attachment urls for use in page header media background
  * @param array $images Assoc. array of image Attachment IDs for use in page header media background
  * @return string HTML for the page header
  **/

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -204,7 +204,7 @@ add_action( 'wp_head', 'ucfwp_google_tag_manager', 3 );
 
 
 /**
- * Prints the Google Tag Manager noscript snippet using the GTM ID in Theme Options.
+ * Prints the Google Tag Manager noscript snippet using the GTM ID set in the customizer.
  **/
 function ucfwp_google_tag_manager_noscript() {
 	$gtm_id = get_theme_mod( 'gtm_id' );
@@ -232,4 +232,4 @@ function ucfwp_add_favicon_default() {
 	endif;
 }
 
-add_filter( 'wp_head', 'ucfwp_add_favicon_default' );
+add_action( 'wp_head', 'ucfwp_add_favicon_default' );

--- a/readme.markdown
+++ b/readme.markdown
@@ -2,44 +2,19 @@
 
 A generic, responsive WordPress theme for UCF websites, built off of the [Athena Framework](https://ucf.github.io/Athena-Framework/). Suitable as a standalone theme or as a parent theme.
 
+## Quick links
 
-## Installation Requirements
+* [**Theme Documentation**](https://github.com/UCF/UCF-WordPress-Theme/wiki)
+* [Development](#development)
+* [Contributing](#contributing)
 
-This theme is developed and tested against WordPress 4.9.8+ and PHP 5.4.x+.
+-----
 
-### Required Plugins
-These plugins *must* be activated for the theme to function properly.
-* [Advanced Custom Fields PRO](https://www.advancedcustomfields.com/pro/)
+## Documentation
 
-### Supported Plugins
-The plugins listed below are extended upon in this theme--this may include custom layouts for feeds, style modifications, etc. These plugins are not technically required on sites running this theme, and shouldn't be activated on sites that don't require their features. A plugin does not have to be listed here to be compatible with this themes that don't require their features. A plugin does not have to be listed here to be compatible with this theme.
-* [Athena Shortcodes](https://github.com/UCF/Athena-Shortcodes-Plugin)
-* [Automatic Sections Menus Shortcode](https://github.com/UCF/Section-Menus-Shortcode)
-* [UCF Academic Calendar Plugin](https://github.com/UCF/UCF-Academic-Calendar-Plugin)
-* [UCF Alert Plugin](https://github.com/UCF/UCF-Alert-Plugin)
-* [UCF Charts Plugin](https://github.com/UCF/UCF-Charts-Plugin)
-* [UCF College Custom Taxonomy](https://github.com/UCF/UCF-Colleges-Tax-Plugin)
-* [UCF Events](https://github.com/UCF/UCF-Events-Plugin)
-* [UCF Footer](https://github.com/UCF/UCF-Footer-Plugin)
-* [UCF News](https://github.com/UCF/UCF-News-Plugin)
-* [UCF Pegasus List Shortcode](https://github.com/UCF/UCF-Pegasus-List-Shortcode)
-* [UCF People Custom Post Type](https://github.com/UCF/UCF-People-CPT)
-* [UCF Post List Shortcode](https://github.com/UCF/UCF-Post-List-Shortcode)
-* [UCF Section](https://github.com/UCF/UCF-Section-Plugin)
-* [UCF Social](https://github.com/UCF/UCF-Social-Plugin)
-* [UCF Spotlights](https://github.com/UCF/UCF-Spotlights-Plugin)
-* [UCF Weather Shortcode](https://github.com/UCF/UCF-Weather-Shortcode)
-* [WP Shortcode Interface](https://github.com/UCF/WP-Shortcode-Interface)
-* [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/)
+Head over to the [UCF WordPress Theme wiki](https://github.com/UCF/UCF-WordPress-Theme/wiki) for detailed information about this theme, installation instructions, and more.
 
-
-## Configuration
-
-* Import field groups (`dev/acf-fields.json`) using the ACF importer under Custom Fields > Tools.
-* Create and set a static front page under Settings > Reading.
-* If your site requires primary navigation, create a menu and assign it to the Header Menu location.  If no Header Menu is set, ucf.edu's primary navigation will be used.
-* If you plan on using [premium webfonts using Cloud.Typography](https://ucf.github.io/Athena-Framework/getting-started/install/#cloudtypography-premium-font-configuration), ensure that webfonts have been properly configured to a Cloud.Typography CSS Key that [allows access to your environment](https://dashboard.typography.com/user-guide/managing-domains). A Cloud.Typography CSS Key URL can be added via the WordPress Customizer (Appearance > Customize > Web Fonts).
-
+-----
 
 ## Development
 
@@ -52,10 +27,20 @@ Note that compiled, minified css and js files are included within the repo.  Cha
 * gulp-cli
 
 ### Instructions
-1. Clone the UCF-WordPress-Theme repo into your development environment, within your WordPress installation's `themes/` directory: `git clone https://github.com/UCF/UCF-WordPress-Theme.git`
-2. `cd` into the UCF-WordPress-Theme directory, and run `npm install` to install required packages for development into `node_modules/` within the repo
-3. Copy `gulp-config.template.json`, make any desired changes, and save as `gulp-config.json`.
+1. Clone the UCF-WordPress-Theme repo into your local development environment, within your WordPress installation's `themes/` directory: `git clone https://github.com/UCF/UCF-WordPress-Theme.git`
+2. `cd` into the new UCF-WordPress-Theme directory, and run `npm install` to install required packages for development into `node_modules/` within the repo
+3. Optional: If you'd like to enable [BrowserSync](https://browsersync.io) for local development, or make other changes to this project's default gulp configuration, copy `gulp-config.template.json`, make any desired changes, and save as `gulp-config.json`.
+
+    To enable BrowserSync, set `sync` to `true` and assign `syncTarget` the base URL of a site on your local WordPress instance that will use this theme, such as `http://localhost/wordpress/my-site/`.  Your `syncTarget` value will vary depending on your local host setup.
+
+    The full list of modifiable config values can be viewed in `gulpfile.js` (see `config` variable).
 3. Run `gulp default` to process front-end assets.
-4. If you haven't already done so, create a new WordPress site on your development environment, install the required plugins listed above, and set the UCF WordPress Theme as the active theme.
-5. Make sure you've done all the steps listed under "Configuration" above.
-6. Run `gulp watch` to continuously watch changes to scss and js files.  If you enabled BrowserSync in `gulp-config.json`, it will also reload your browser when scss or js files change.
+4. If you haven't already done so, create a new WordPress site on your development environment, and [install and activate theme dependencies](https://github.com/UCF/UCF-WordPress-Theme/wiki/Installation#installation-requirements).
+5. Set the UCF WordPress Theme as the active theme.
+6. Make sure you've completed [all theme configuration steps](https://github.com/UCF/UCF-WordPress-Theme/wiki/Installation#theme-configuration).
+7. Run `gulp watch` to continuously watch changes to scss and js files.  If you enabled BrowserSync in `gulp-config.json`, it will also reload your browser when scss or js files change.
+
+
+## Contributing
+
+Want to submit a bug report or feature request?  Check out our [contributing guidelines](https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md) for more information.  We'd love to hear from you!


### PR DESCRIPTION
Updated a few things as I was working on documentation for the theme:

- Updated comments in theme code that were inaccurate
- Fixed usage of `add_filter()` when registering the `ucfwp_add_favicon_default` hook (`wp_head` is an action hook)
- Updated readme to primarily point to the wiki for documentation, requirements, and installation instructions