### PR TITLE
Template parts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -9,9 +9,9 @@ include_once 'includes/activate.php';
 include_once 'includes/utilities.php';
 include_once 'includes/config.php';
 include_once 'includes/meta.php';
-include_once 'includes/navwalker.php';
 include_once 'includes/galleries.php';
 include_once 'includes/media-backgrounds.php';
+include_once 'includes/nav-functions.php';
 include_once 'includes/header-functions.php';
 include_once 'includes/footer-functions.php';
 

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,7 @@
 <?php
+// Deprecated functions
+include_once 'includes/deprecated.php';
+
 // Activation checks
 include_once 'includes/activate.php';
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -8,7 +8,7 @@ define( 'UCFWP_THEME_STATIC_URL', UCFWP_THEME_URL . '/static' );
 define( 'UCFWP_THEME_CSS_URL', UCFWP_THEME_STATIC_URL . '/css' );
 define( 'UCFWP_THEME_JS_URL', UCFWP_THEME_STATIC_URL . '/js' );
 define( 'UCFWP_THEME_IMG_URL', UCFWP_THEME_STATIC_URL . '/img' );
-define( 'UCFWP_THEME_TEMPLATE_PARTS_PATH', '/template-parts' );
+define( 'UCFWP_THEME_TEMPLATE_PARTS_PATH', 'template-parts' );
 define( 'UCFWP_THEME_CUSTOMIZER_PREFIX', 'ucfwp_' );
 define( 'UCFWP_MAINSITE_NAV_URL', 'https://www.ucf.edu/wp-json/ucf-rest-menus/v1/menus/23' );
 define( 'UCFWP_THEME_CUSTOMIZER_DEFAULTS', serialize( array(

--- a/includes/config.php
+++ b/includes/config.php
@@ -8,6 +8,7 @@ define( 'UCFWP_THEME_STATIC_URL', UCFWP_THEME_URL . '/static' );
 define( 'UCFWP_THEME_CSS_URL', UCFWP_THEME_STATIC_URL . '/css' );
 define( 'UCFWP_THEME_JS_URL', UCFWP_THEME_STATIC_URL . '/js' );
 define( 'UCFWP_THEME_IMG_URL', UCFWP_THEME_STATIC_URL . '/img' );
+define( 'UCFWP_THEME_TEMPLATE_PARTS_PATH', '/template-parts' );
 define( 'UCFWP_THEME_CUSTOMIZER_PREFIX', 'ucfwp_' );
 define( 'UCFWP_MAINSITE_NAV_URL', 'https://www.ucf.edu/wp-json/ucf-rest-menus/v1/menus/23' );
 define( 'UCFWP_THEME_CUSTOMIZER_DEFAULTS', serialize( array(

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -132,3 +132,21 @@ if ( !function_exists( 'ucfwp_get_header_default_markup' ) ) {
 		return ob_get_clean();
 	}
 }
+
+
+/**
+ * Returns inner navbar markup for ucf.edu's primary site navigation.
+ *
+ * @since 0.0.0
+ * @author Jo Dickson
+ * @return string HTML markup
+ */
+if ( !function_exists( 'ucfwp_get_mainsite_menu' ) ) {
+	function ucfwp_get_mainsite_menu( $image=true ) {
+		set_query_var( 'ucfwp_image_behind_nav', $image );
+
+		ob_start();
+		get_template_part( ucfwp_get_template_part_slug( 'header' ), 'mainsite' );
+		return ob_get_clean();
+	}
+}

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -63,7 +63,7 @@ function ucfwp_get_object_field_id( $obj ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @deprecated 0.4.0 Use get_template_part()
+ * @deprecated 0.4.0 Use ucfwp_get_header_content_markup()
  * @param object $obj A WP_Post or WP_Term object
  * @return string HTML for the page title + subtitle
  **/
@@ -83,7 +83,7 @@ if ( !function_exists( 'ucfwp_get_header_content_title_subtitle' ) ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @deprecated 0.4.0 Use get_template_part()
+ * @deprecated 0.4.0 Use ucfwp_get_header_content_markup()
  * @param object $obj A WP_Post or WP_Term object
  * @return string HTML for the custom page header contents
  **/
@@ -103,7 +103,7 @@ if ( !function_exists( 'ucfwp_get_header_content_custom' ) ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @deprecated 0.4.0 Use get_template_part()
+ * @deprecated 0.4.0 Use ucfwp_get_header_markup()
  * @param object $obj A WP_Post or WP_Term object
  * @param array $videos Deprecated
  * @param array $images Deprecated
@@ -125,7 +125,7 @@ if ( !function_exists( 'ucfwp_get_header_media_markup' ) ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @deprecated 0.4.0 Use get_template_part()
+ * @deprecated 0.4.0 Use ucfwp_get_header_markup()
  * @param object $obj A WP_Post or WP_Term object
  * @return string HTML for the page header
  **/
@@ -145,7 +145,7 @@ if ( !function_exists( 'ucfwp_get_header_default_markup' ) ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @deprecated 0.4.0 Use get_template_part()
+ * @deprecated 0.4.0 Use ucfwp_get_nav_markup()
  * @return string HTML markup
  */
 if ( !function_exists( 'ucfwp_get_mainsite_menu' ) ) {

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -13,6 +13,7 @@
  * or null.
  *
  * @since 0.0.0
+ * @deprecated 0.4.0
  * @author Jo Dickson
  * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return mixed Post or Term object ID integer, or null on failure
@@ -37,6 +38,7 @@ function ucfwp_get_object_id( $obj ) {
  *
  * @see https://www.advancedcustomfields.com/resources/get_field/ ACF get_field() docs (scroll to "Get a value from different objects")
  * @since 0.0.0
+ * @deprecated 0.4.0 Pass the entire queried object to get_field() instead
  * @author Jo Dickson
  * @param object $obj WP_Post or WP_Term object
  * @return mixed ACF $post_id argument for the Post or Term, or null on failure
@@ -61,6 +63,7 @@ function ucfwp_get_object_field_id( $obj ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
+ * @deprecated 0.4.0 Use get_template_part()
  * @param object $obj A WP_Post or WP_Term object
  * @return string HTML for the page title + subtitle
  **/
@@ -80,6 +83,7 @@ if ( !function_exists( 'ucfwp_get_header_content_title_subtitle' ) ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
+ * @deprecated 0.4.0 Use get_template_part()
  * @param object $obj A WP_Post or WP_Term object
  * @return string HTML for the custom page header contents
  **/
@@ -99,6 +103,7 @@ if ( !function_exists( 'ucfwp_get_header_content_custom' ) ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
+ * @deprecated 0.4.0 Use get_template_part()
  * @param object $obj A WP_Post or WP_Term object
  * @param array $videos Deprecated
  * @param array $images Deprecated
@@ -120,6 +125,7 @@ if ( !function_exists( 'ucfwp_get_header_media_markup' ) ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
+ * @deprecated 0.4.0 Use get_template_part()
  * @param object $obj A WP_Post or WP_Term object
  * @return string HTML for the page header
  **/
@@ -137,8 +143,9 @@ if ( !function_exists( 'ucfwp_get_header_default_markup' ) ) {
 /**
  * Returns inner navbar markup for ucf.edu's primary site navigation.
  *
- * @since 0.0.0
  * @author Jo Dickson
+ * @since 0.0.0
+ * @deprecated 0.4.0 Use get_template_part()
  * @return string HTML markup
  */
 if ( !function_exists( 'ucfwp_get_mainsite_menu' ) ) {

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * The functions in this file are included for the sake of backward
+ * compatibility within the current major version of the theme.
+ * They will be removed in the next major release.
+ *
+ * Do not use the functions below in new code.
+ */
+
+
+/**
+ * Given a queried object, returns the relevant object ID property
+ * or null.
+ *
+ * @since 0.0.0
+ * @author Jo Dickson
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
+ * @return mixed Post or Term object ID integer, or null on failure
+ **/
+function ucfwp_get_object_id( $obj ) {
+	$obj_id = null;
+
+	if ( $obj instanceof WP_Post ) {
+		$obj_id = $obj->ID;
+	}
+	else if ( $obj instanceof WP_Term ) {
+		$obj_id = $obj->term_id;
+	}
+
+	return $obj_id;
+}
+
+
+/**
+ * Given a WP_Term or WP_Post object, returns the relevant $post_id argument
+ * for ACF field retrieval/modification functions (e.g. get_field()) or null.
+ *
+ * @see https://www.advancedcustomfields.com/resources/get_field/ ACF get_field() docs (scroll to "Get a value from different objects")
+ * @since 0.0.0
+ * @author Jo Dickson
+ * @param object $obj WP_Post or WP_Term object
+ * @return mixed ACF $post_id argument for the Post or Term, or null on failure
+ **/
+function ucfwp_get_object_field_id( $obj ) {
+	$field_id = null;
+
+	if ( $obj instanceof WP_Post ) {
+		$field_id = $obj->ID;
+	}
+	else if ( $obj instanceof WP_Term ) {
+		$field_id = $obj->taxonomy . '_' . $obj->term_id;
+	}
+
+	return $field_id;
+}
+
+
+/**
+ * Returns markup for page header title + subtitles within headers that use a
+ * media background.
+ *
+ * @author Jo Dickson
+ * @since 0.0.0
+ * @param object $obj A WP_Post or WP_Term object
+ * @return string HTML for the page title + subtitle
+ **/
+if ( !function_exists( 'ucfwp_get_header_content_title_subtitle' ) ) {
+	function ucfwp_get_header_content_title_subtitle( $obj ) {
+		set_query_var( 'ucfwp_obj', $obj );
+
+		ob_start();
+		get_template_part( ucfwp_get_template_part_slug( 'header_content' ), 'title_subtitle' );
+		return ob_get_clean();
+	}
+}
+
+
+/**
+ * Returns markup for page header custom content.
+ *
+ * @author Jo Dickson
+ * @since 0.0.0
+ * @param object $obj A WP_Post or WP_Term object
+ * @return string HTML for the custom page header contents
+ **/
+if ( !function_exists( 'ucfwp_get_header_content_custom' ) ) {
+	function ucfwp_get_header_content_custom( $obj ) {
+		set_query_var( 'ucfwp_obj', $obj );
+
+		ob_start();
+		get_template_part( ucfwp_get_template_part_slug( 'header_content' ), 'custom' );
+		return ob_get_clean();
+	}
+}
+
+
+/**
+ * Returns the markup for page headers with media backgrounds.
+ *
+ * @author Jo Dickson
+ * @since 0.0.0
+ * @param object $obj A WP_Post or WP_Term object
+ * @param array $videos Deprecated
+ * @param array $images Deprecated
+ * @return string HTML for the page header
+ **/
+if ( !function_exists( 'ucfwp_get_header_media_markup' ) ) {
+	function ucfwp_get_header_media_markup( $obj, $videos, $images ) {
+		set_query_var( 'ucfwp_obj', $obj );
+
+		ob_start();
+		get_template_part( ucfwp_get_template_part_slug( 'header' ), 'media' );
+		return ob_get_clean();
+	}
+}
+
+
+/**
+ * Returns the default markup for page headers without a media background.
+ *
+ * @author Jo Dickson
+ * @since 0.0.0
+ * @param object $obj A WP_Post or WP_Term object
+ * @return string HTML for the page header
+ **/
+if ( !function_exists( 'ucfwp_get_header_default_markup' ) ) {
+	function ucfwp_get_header_default_markup( $obj ) {
+		set_query_var( 'ucfwp_obj', $obj );
+
+		ob_start();
+		get_template_part( ucfwp_get_template_part_slug( 'header' ) );
+		return ob_get_clean();
+	}
+}

--- a/includes/footer-functions.php
+++ b/includes/footer-functions.php
@@ -4,6 +4,22 @@
  **/
 
 /**
+ * Returns the type of footer to use for the given object.
+ * The value returned will represent an equivalent template part's name.
+ *
+ * @author Jo Dickson
+ * @since TODO
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
+ * @return string The footer type name
+ */
+function ucfwp_get_footer_type( $obj ) {
+	$footer_type = '';
+
+	return apply_filters( 'ucfwp_get_footer_type', $footer_type, $obj );
+}
+
+
+/**
  * Returns markup for the site footer. Will return an empty string if all
  * footer sidebars are empty.
  *
@@ -13,49 +29,15 @@
  **/
 if ( !function_exists( 'ucfwp_get_footer_markup' ) ) {
 	function ucfwp_get_footer_markup() {
+		$retval = '';
+		$obj    = ucfwp_get_queried_object();
+
+		$template_part_name = ucfwp_get_footer_type( $obj );
+
 		ob_start();
+		get_template_part( ucfwp_get_template_part_slug( 'footer' ), $template_part_name );
+		$retval = ob_get_clean();
 
-		if (
-			is_active_sidebar( 'footer-col-1' )
-			|| is_active_sidebar( 'footer-col-2' )
-			|| is_active_sidebar( 'footer-col-3' )
-			|| is_active_sidebar( 'footer-col-4' )
-		):
-	?>
-		<footer class="site-footer bg-inverse pt-4 py-md-5">
-			<div class="container mt-4">
-				<div class="row">
-
-				<?php if ( is_active_sidebar( 'footer-col-1' ) ): ?>
-					<section class="col-12 col-lg">
-						<?php dynamic_sidebar( 'footer-col-1' ); ?>
-					</section>
-				<?php endif; ?>
-
-				<?php if ( is_active_sidebar( 'footer-col-2' ) ): ?>
-					<section class="col-12 col-lg">
-						<?php dynamic_sidebar( 'footer-col-2' ); ?>
-					</section>
-				<?php endif; ?>
-
-				<?php if ( is_active_sidebar( 'footer-col-3' ) ): ?>
-					<section class="col-12 col-lg">
-						<?php dynamic_sidebar( 'footer-col-3' ); ?>
-					</section>
-				<?php endif; ?>
-
-				<?php if ( is_active_sidebar( 'footer-col-4' ) ): ?>
-					<section class="col-12 col-lg">
-						<?php dynamic_sidebar( 'footer-col-4' ); ?>
-					</section>
-				<?php endif; ?>
-
-				</div>
-			</div>
-		</footer>
-	<?php
-		endif;
-
-		return ob_get_clean();
+		return apply_filters( 'ucfwp_get_footer_markup', $retval, $obj );
 	}
 }

--- a/includes/footer-functions.php
+++ b/includes/footer-functions.php
@@ -32,10 +32,11 @@ if ( !function_exists( 'ucfwp_get_footer_markup' ) ) {
 		$retval = '';
 		$obj    = ucfwp_get_queried_object();
 
+		$template_part_slug = ucfwp_get_template_part_slug( 'footer' );
 		$template_part_name = ucfwp_get_footer_type( $obj );
 
 		ob_start();
-		get_template_part( ucfwp_get_template_part_slug( 'footer' ), $template_part_name );
+		get_template_part( $template_part_slug, $template_part_name );
 		$retval = ob_get_clean();
 
 		return apply_filters( 'ucfwp_get_footer_markup', $retval, $obj );

--- a/includes/footer-functions.php
+++ b/includes/footer-functions.php
@@ -8,7 +8,7 @@
  * The value returned will represent an equivalent template part's name.
  *
  * @author Jo Dickson
- * @since TODO
+ * @since 0.4.0
  * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return string The footer type name
  */

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -255,6 +255,30 @@ if ( ! function_exists( 'ucfwp_get_header_type' ) ) {
 
 
 /**
+ * Returns header markup for the current object.
+ *
+ * @author Jo Dickson
+ * @since 0.0.0
+ * @return string HTML for the page header
+ **/
+if ( !function_exists( 'ucfwp_get_header_markup' ) ) {
+	function ucfwp_get_header_markup() {
+		$retval = '';
+		$obj    = ucfwp_get_queried_object();
+
+		$template_part_slug = ucfwp_get_template_part_slug( 'header' );
+		$template_part_name = ucfwp_get_header_type( $obj );
+
+		ob_start();
+		_ucfwp_get_template_part( $template_part_slug, $template_part_name );
+		$retval = ob_get_clean();
+
+		return apply_filters( 'ucfwp_get_header_markup', $retval, $obj );
+	}
+}
+
+
+/**
  * Returns the header content type for the given page's header.
  * The value returned will represent an equivalent template part's name.
  *
@@ -281,24 +305,24 @@ if ( ! function_exists( 'ucfwp_get_header_content_type' ) ) {
 
 
 /**
- * Returns header markup for the current object.
+ * Returns header content markup for the current object.
  *
  * @author Jo Dickson
- * @since 0.0.0
- * @return string HTML for the page header
- **/
-if ( !function_exists( 'ucfwp_get_header_markup' ) ) {
-	function ucfwp_get_header_markup() {
+ * @since 0.4.0
+ * @return string HTML for the page header's inner contents
+ */
+if ( !function_exists( 'ucfwp_get_header_content_markup' ) ) {
+	function ucfwp_get_header_content_markup() {
 		$retval = '';
 		$obj    = ucfwp_get_queried_object();
 
-		$template_part_slug = ucfwp_get_template_part_slug( 'header' );
-		$template_part_name = ucfwp_get_header_type( $obj );
+		$template_part_slug = ucfwp_get_template_part_slug( 'header_content' );
+		$template_part_name = ucfwp_get_header_content_type( $obj );
 
 		ob_start();
 		_ucfwp_get_template_part( $template_part_slug, $template_part_name );
 		$retval = ob_get_clean();
 
-		return apply_filters( 'ucfwp_get_header_markup', $retval, $obj );
+		return apply_filters( 'ucfwp_get_header_content_markup', $retval, $obj );
 	}
 }

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -235,7 +235,7 @@ if ( !function_exists( 'ucfwp_get_header_h1_option' ) ) {
  * The value returned will represent an equivalent template part's name.
  *
  * @author Jo Dickson
- * @since TODO
+ * @since 0.4.0
  * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return string The header type name
  */
@@ -259,7 +259,7 @@ if ( ! function_exists( 'ucfwp_get_header_type' ) ) {
  * The value returned will represent an equivalent template part's name.
  *
  * @author Jo Dickson
- * @since TODO
+ * @since 0.4.0
  * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return string The content type name
  */

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -559,7 +559,8 @@ if ( !function_exists( 'ucfwp_get_header_default_markup' ) ) {
  **/
 if ( !function_exists( 'ucfwp_get_header_markup' ) ) {
 	function ucfwp_get_header_markup() {
-		$obj = get_queried_object();
+		$retval = '';
+		$obj    = get_queried_object();
 
 		if ( !$obj && is_404() ) {
 			$page = get_page_by_title( '404' );
@@ -571,12 +572,18 @@ if ( !function_exists( 'ucfwp_get_header_markup' ) ) {
 		$videos = ucfwp_get_header_videos( $obj );
 		$images = ucfwp_get_header_images( $obj );
 
+		$retval = apply_filters( 'ucfwp_get_header_markup_before', $retval, $obj, $videos, $images );
+		// Return early if alternate markup was provided:
+		if ( $retval ) { return $retval; }
+
 		if ( $videos || $images ) {
-			echo ucfwp_get_header_media_markup( $obj, $videos, $images );
+			$retval = ucfwp_get_header_media_markup( $obj, $videos, $images );
 		}
 		else {
-			echo ucfwp_get_header_default_markup( $obj );
+			$retval = ucfwp_get_header_default_markup( $obj );
 		}
+
+		return apply_filters( 'ucfwp_get_header_markup_after', $retval, $obj, $videos, $images );
 	}
 }
 
@@ -603,7 +610,7 @@ if ( !function_exists( 'ucfwp_get_subnav_markup' ) ) {
 		$include_subnav = get_field( 'page_header_include_subnav', $field_id );
 
 		if ( class_exists( 'Section_Menus_Common' ) && $include_subnav ) {
-			echo do_shortcode( '[section-menu]' );
+			return do_shortcode( '[section-menu]' );
 		}
 	}
 }

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -295,8 +295,6 @@ if ( !function_exists( 'ucfwp_get_header_markup' ) ) {
 		$template_part_slug = ucfwp_get_template_part_slug( 'header' );
 		$template_part_name = ucfwp_get_header_type( $obj );
 
-		set_query_var( 'ucfwp_obj', $obj );
-
 		ob_start();
 		_ucfwp_get_template_part( $template_part_slug, $template_part_name );
 		$retval = ob_get_clean();

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -9,13 +9,10 @@
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @param object $obj A WP_Post or WP_Term object
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return array A set of Attachment IDs, one sized for use on -sm+ screens, and another for -xs
  **/
 function ucfwp_get_header_images( $obj ) {
-	$obj_id = ucfwp_get_object_id( $obj );
-	$field_id = ucfwp_get_object_field_id( $obj );
-
 	$retval = array(
 		'header_image'    => '',
 		'header_image_xs' => ''
@@ -27,10 +24,10 @@ function ucfwp_get_header_images( $obj ) {
 		return $retval;
 	}
 
-	if ( $obj_header_image = get_field( 'page_header_image', $field_id ) ) {
+	if ( $obj_header_image = get_field( 'page_header_image', $obj ) ) {
 		$retval['header_image'] = $obj_header_image;
 	}
-	if ( $obj_header_image_xs = get_field( 'page_header_image_xs', $field_id ) ) {
+	if ( $obj_header_image_xs = get_field( 'page_header_image_xs', $obj ) ) {
 		$retval['header_image_xs'] = $obj_header_image_xs;
 	}
 
@@ -49,13 +46,10 @@ function ucfwp_get_header_images( $obj ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @param object $obj A WP_Post or WP_Term object
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return array A set of Attachment urls corresponding to available video filetypes
  **/
 function ucfwp_get_header_videos( $obj ) {
-	$obj_id = ucfwp_get_object_id( $obj );
-	$field_id = ucfwp_get_object_field_id( $obj );
-
 	$retval = array(
 		'webm' => '',
 		'mp4'  => ''
@@ -68,10 +62,10 @@ function ucfwp_get_header_videos( $obj ) {
 		return $retval;
 	}
 
-	if ( $obj_header_video_mp4 = get_field( 'page_header_mp4', $field_id ) ) {
+	if ( $obj_header_video_mp4 = get_field( 'page_header_mp4', $obj ) ) {
 		$retval['mp4'] = $obj_header_video_mp4;
 	}
-	if ( $obj_header_video_webm = get_field( 'page_header_webm', $field_id ) ) {
+	if ( $obj_header_video_webm = get_field( 'page_header_webm', $obj ) ) {
 		$retval['webm'] = $obj_header_video_webm;
 	}
 
@@ -91,11 +85,10 @@ function ucfwp_get_header_videos( $obj ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @param object $obj A WP_Post or WP_Term object
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return string Header title text
  **/
  function ucfwp_get_header_title( $obj ) {
-	$field_id = ucfwp_get_object_field_id( $obj );
 	$title = '';
 
 	// Exit early if the title has been overridden early
@@ -142,7 +135,7 @@ function ucfwp_get_header_videos( $obj ) {
 	}
 
 	// Apply custom header title override, if available
-	if ( $custom_header_title = get_field( 'page_header_title', $field_id ) ) {
+	if ( $custom_header_title = get_field( 'page_header_title', $obj ) ) {
 		$title = do_shortcode( $custom_header_title );
 	}
 
@@ -157,11 +150,10 @@ function ucfwp_get_header_videos( $obj ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @param object $obj A WP_Post or WP_Term object
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return string Header subtitle text
  **/
 function ucfwp_get_header_subtitle( $obj ) {
-	$field_id = ucfwp_get_object_field_id( $obj );
 	$subtitle = '';
 
 	$subtitle = (string) apply_filters( 'ucfwp_get_header_subtitle_before', $subtitle, $obj );
@@ -170,7 +162,7 @@ function ucfwp_get_header_subtitle( $obj ) {
 		return wptexturize( $subtitle );
 	}
 
-	$subtitle = do_shortcode( get_field( 'page_header_subtitle', $field_id ) );
+	$subtitle = do_shortcode( get_field( 'page_header_subtitle', $obj ) );
 
 	$subtitle = (string) apply_filters( 'ucfwp_get_header_subtitle_after', $subtitle, $obj );
 
@@ -186,14 +178,13 @@ function ucfwp_get_header_subtitle( $obj ) {
  *
  * @author Jo Dickson
  * @since 0.0.0
- * @param object $obj A WP_Post or WP_Term object
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return string Option value for the designated page header h1
  **/
 if ( !function_exists( 'ucfwp_get_header_h1_option' ) ) {
 	function ucfwp_get_header_h1_option( $obj ) {
-		$field_id = ucfwp_get_object_field_id( $obj );
-		$subtitle = get_field( 'page_header_subtitle', $field_id ) ?: '';
-		$h1       = get_field( 'page_header_h1', $field_id ) ?: 'title';
+		$subtitle = get_field( 'page_header_subtitle', $obj ) ?: '';
+		$h1       = get_field( 'page_header_h1', $obj ) ?: 'title';
 
 		if ( $h1 === 'subtitle' && trim( $subtitle ) === '' ) {
 			$h1 = 'title';
@@ -205,7 +196,57 @@ if ( !function_exists( 'ucfwp_get_header_h1_option' ) ) {
 
 
 /**
+ * Returns the type of header to use for the given object.
+ * The value returned will represent an equivalent template part's name.
+ *
+ * @author Jo Dickson
+ * @since TODO
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
+ * @return string The header type name
+ */
+if ( ! function_exists( 'ucfwp_get_header_type' ) ) {
+	function ucfwp_get_header_type( $obj ) {
+		$header_type = '';
+
+		$videos = ucfwp_get_header_videos( $obj );
+		$images = ucfwp_get_header_images( $obj );
+		if ( $videos || $images ) {
+			$header_type = 'media';
+		}
+
+		return apply_filters( 'ucfwp_get_header_type', $header_type, $obj );
+	}
+}
+
+
+/**
+ * Returns the header content type for the given page's header.
+ * The value returned will represent an equivalent template part's name.
+ *
+ * @author Jo Dickson
+ * @since TODO
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
+ * @return string The content type name
+ */
+function ucfwp_get_header_content_type( $obj ) {
+	$content_type = get_field( 'page_header_content_type', $obj ) ?: '';
+	$header_type  = ucfwp_get_header_type( $obj );
+
+	// Required for compatibility with existing content type names:
+	// set $header_content_type to an empty string to force the 'default'
+	// header_content partial to be returned
+	if ( $header_type === '' && $content_type === 'title_subtitle' ) {
+		$content_type = '';
+	}
+
+	return apply_filters( 'ucfwp_get_header_content_type', $content_type, $obj );
+}
+
+
+/**
  * Returns inner navbar markup for ucf.edu's primary site navigation.
+ *
+ * TODO move markup to template part
  *
  * @since 0.0.0
  * @author Jo Dickson
@@ -268,6 +309,8 @@ if ( !function_exists( 'ucfwp_get_mainsite_menu' ) ) {
  * Returns HTML markup for the primary site navigation.  Falls back to the
  * ucf.edu primary navigation if a header menu is not set.
  *
+ * TODO move markup to template part
+ *
  * @author Jo Dickson
  * @since 0.0.0
  * @param bool $image Whether or not a media background is present in the page header.
@@ -320,77 +363,6 @@ if ( !function_exists( 'ucfwp_get_nav_markup' ) ) {
 
 
 /**
- * Returns markup for page header title + subtitles within headers that use a
- * media background.
- *
- * @author Jo Dickson
- * @since 0.0.0
- * @param object $obj A WP_Post or WP_Term object
- * @return string HTML for the page title + subtitle
- **/
-if ( !function_exists( 'ucfwp_get_header_content_title_subtitle' ) ) {
-	function ucfwp_get_header_content_title_subtitle( $obj ) {
-		$title         = ucfwp_get_header_title( $obj );
-		$subtitle      = ucfwp_get_header_subtitle( $obj );
-		$h1            = ucfwp_get_header_h1_option( $obj );
-		$h1_elem       = ( is_home() || is_front_page() ) ? 'h2' : 'h1'; // name is misleading but we need to override this elem on the homepage
-		$title_elem    = ( $h1 === 'title' ) ? $h1_elem : 'span';
-		$subtitle_elem = ( $h1 === 'subtitle' ) ? $h1_elem : 'span';
-
-		ob_start();
-
-		if ( $title ):
-	?>
-		<div class="header-content-inner align-self-start pt-4 pt-sm-0 align-self-sm-center">
-			<div class="container">
-				<div class="d-inline-block bg-primary-t-1">
-					<<?php echo $title_elem; ?> class="header-title"><?php echo $title; ?></<?php echo $title_elem; ?>>
-				</div>
-				<?php if ( $subtitle ) : ?>
-				<div class="clearfix"></div>
-				<div class="d-inline-block bg-inverse">
-					<<?php echo $subtitle_elem; ?> class="header-subtitle"><?php echo $subtitle; ?></<?php echo $subtitle_elem; ?>>
-				</div>
-				<?php endif; ?>
-			</div>
-		</div>
-	<?php
-		endif;
-
-		return ob_get_clean();
-	}
-}
-
-
-/**
- * Returns markup for page header custom content.
- *
- * @author Jo Dickson
- * @since 0.0.0
- * @param object $obj A WP_Post or WP_Term object
- * @return string HTML for the custom page header contents
- **/
-if ( !function_exists( 'ucfwp_get_header_content_custom' ) ) {
-	function ucfwp_get_header_content_custom( $obj ) {
-		$field_id = ucfwp_get_object_field_id( $obj );
-		$content = get_field( 'page_header_content', $field_id );
-
-		ob_start();
-	?>
-		<div class="header-content-inner">
-	<?php
-		if ( $content ) {
-			echo $content;
-		}
-	?>
-		</div>
-	<?php
-		return ob_get_clean();
-	}
-}
-
-
-/**
  * Returns an array of src's for a page header's media background
  * <picture> <source>s, by breakpoint.  Will return a unique set of src's
  * depending on the page's header height.
@@ -426,132 +398,7 @@ if ( ! function_exists( 'ucfwp_get_header_media_picture_srcs' ) ) {
 
 
 /**
- * Returns the markup for page headers with media backgrounds.
- *
- * @author Jo Dickson
- * @since 0.0.0
- * @param object $obj A WP_Post or WP_Term object
- * @param array $videos Assoc. array of video Attachment urls for use in page header media background
- * @param array $images Assoc. array of image Attachment IDs for use in page header media background
- * @return string HTML for the page header
- **/
-if ( !function_exists( 'ucfwp_get_header_media_markup' ) ) {
-	function ucfwp_get_header_media_markup( $obj, $videos, $images ) {
-		$field_id   = ucfwp_get_object_field_id( $obj );
-		$videos     = $videos ?: ucfwp_get_header_videos( $obj );
-		$images     = $images ?: ucfwp_get_header_images( $obj );
-		$video_loop = get_field( 'page_header_video_loop', $field_id );
-		$header_content_type = get_field( 'page_header_content_type', $field_id );
-		$header_height       = get_field( 'page_header_height', $field_id );
-		$exclude_nav         = get_field( 'page_header_exclude_nav', $field_id );
-
-		ob_start();
-	?>
-		<div class="header-media <?php echo $header_height; ?> mb-0 d-flex flex-column">
-			<div class="header-media-background-wrap">
-				<div class="header-media-background media-background-container">
-					<?php
-					// Display the media background (video + picture)
-
-					if ( $videos ) {
-						echo ucfwp_get_media_background_video( $videos, $video_loop );
-					}
-					if ( $images ) {
-						$bg_image_srcs = ucfwp_get_header_media_picture_srcs( $header_height, $images );
-						echo ucfwp_get_media_background_picture( $bg_image_srcs );
-					}
-					?>
-				</div>
-			</div>
-
-			<?php
-			// Display the site nav
-			if ( !$exclude_nav ) { echo ucfwp_get_nav_markup(); }
-			?>
-
-			<?php
-			// Display the inner header contents
-			?>
-			<div class="header-content">
-				<div class="header-content-flexfix">
-					<?php
-					if ( $header_content_type === 'custom' ) {
-						echo ucfwp_get_header_content_custom( $obj );
-					}
-					else {
-						echo ucfwp_get_header_content_title_subtitle( $obj );
-					}
-					?>
-				</div>
-			</div>
-
-			<?php
-			// Print a spacer div for headers with background videos (to make
-			// control buttons accessible), and for headers showing a standard
-			// title/subtitle to push them up a bit
-			if ( $videos || $header_content_type === 'title_subtitle' ):
-			?>
-			<div class="header-media-controlfix"></div>
-			<?php endif; ?>
-		</div>
-	<?php
-		return ob_get_clean();
-	}
-}
-
-
-/**
- * Returns the default markup for page headers without a media background.
- *
- * @author Jo Dickson
- * @since 0.0.0
- * @param object $obj A WP_Post or WP_Term object
- * @return string HTML for the page header
- **/
-if ( !function_exists( 'ucfwp_get_header_default_markup' ) ) {
-	function ucfwp_get_header_default_markup( $obj ) {
-		$title               = ucfwp_get_header_title( $obj );
-		$subtitle            = ucfwp_get_header_subtitle( $obj );
-		$field_id            = ucfwp_get_object_field_id( $obj );
-		$header_content_type = get_field( 'page_header_content_type', $field_id );
-		$exclude_nav         = get_field( 'page_header_exclude_nav', $field_id );
-		$h1                  = ucfwp_get_header_h1_option( $obj );
-		$h1_elem             = ( is_home() || is_front_page() ) ? 'h2' : 'h1'; // name is misleading but we need to override this elem on the homepage
-		$title_elem          = ( $h1 === 'title' ) ? $h1_elem : 'span';
-		$subtitle_elem       = ( $h1 === 'subtitle' ) ? $h1_elem : 'p';
-
-		$title_classes = 'h1 d-block mt-3 mt-sm-4 mt-md-5 mb-2 mb-md-3';
-		$subtitle_classes = 'lead mb-2 mb-md-3';
-
-		ob_start();
-	?>
-		<?php if ( !$exclude_nav ) { echo ucfwp_get_nav_markup( false ); } ?>
-
-		<?php
-		if ( $header_content_type === 'custom' ):
-			echo ucfwp_get_header_content_custom( $obj );
-		elseif ( $title ):
-		?>
-		<div class="container">
-			<<?php echo $title_elem; ?> class="<?php echo $title_classes; ?>">
-				<?php echo $title; ?>
-			</<?php echo $title_elem; ?>>
-
-			<?php if ( $subtitle ): ?>
-				<<?php echo $subtitle_elem; ?> class="<?php echo $subtitle_classes; ?>">
-					<?php echo $subtitle; ?>
-				</<?php echo $subtitle_elem; ?>>
-			<?php endif; ?>
-		</div>
-		<?php endif; ?>
-	<?php
-		return ob_get_clean();
-	}
-}
-
-
-/**
- * Returns header markup for the current post or term.
+ * Returns header markup for the current object.
  *
  * @author Jo Dickson
  * @since 0.0.0
@@ -560,36 +407,24 @@ if ( !function_exists( 'ucfwp_get_header_default_markup' ) ) {
 if ( !function_exists( 'ucfwp_get_header_markup' ) ) {
 	function ucfwp_get_header_markup() {
 		$retval = '';
-		$obj    = get_queried_object();
+		$obj    = ucfwp_get_queried_object();
 
-		if ( !$obj && is_404() ) {
-			$page = get_page_by_title( '404' );
-			if ( $page && $page->post_status === 'publish' ) {
-				$obj = $page;
-			}
-		}
+		$template_part_slug = ucfwp_get_template_part_slug( 'header' );
+		$template_part_name = ucfwp_get_header_type( $obj );
 
-		$videos = ucfwp_get_header_videos( $obj );
-		$images = ucfwp_get_header_images( $obj );
+		set_query_var( 'ucfwp_obj', $obj );
 
-		$retval = apply_filters( 'ucfwp_get_header_markup_before', $retval, $obj, $videos, $images );
-		// Return early if alternate markup was provided:
-		if ( $retval ) { return $retval; }
+		ob_start();
+		_ucfwp_get_template_part( $template_part_slug, $template_part_name );
+		$retval = ob_get_clean();
 
-		if ( $videos || $images ) {
-			$retval = ucfwp_get_header_media_markup( $obj, $videos, $images );
-		}
-		else {
-			$retval = ucfwp_get_header_default_markup( $obj );
-		}
-
-		return apply_filters( 'ucfwp_get_header_markup_after', $retval, $obj, $videos, $images );
+		return apply_filters( 'ucfwp_get_header_markup', $retval, $obj );
 	}
 }
 
 
 /**
- * Returns subnavigation markup for the current post or term.
+ * Returns subnavigation markup for the current object.
  *
  * @author Jo Dickson
  * @since 0.0.0
@@ -597,17 +432,8 @@ if ( !function_exists( 'ucfwp_get_header_markup' ) ) {
  **/
 if ( !function_exists( 'ucfwp_get_subnav_markup' ) ) {
 	function ucfwp_get_subnav_markup() {
-		$obj = get_queried_object();
-
-		if ( !$obj && is_404() ) {
-			$page = get_page_by_title( '404' );
-			if ( $page && $page->post_status === 'publish' ) {
-				$obj = $page;
-			}
-		}
-
-		$field_id       = ucfwp_get_object_field_id( $obj );
-		$include_subnav = get_field( 'page_header_include_subnav', $field_id );
+		$obj = ucfwp_get_queried_object();
+		$include_subnav = get_field( 'page_header_include_subnav', $obj );
 
 		if ( class_exists( 'Section_Menus_Common' ) && $include_subnav ) {
 			return do_shortcode( '[section-menu]' );

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -1,5 +1,74 @@
 <?php
 
+/**
+ * Returns the nav type for the given page's header.
+ * The value returned will represent an equivalent template part's name.
+ *
+ * @author Jo Dickson
+ * @since TODO
+ * @return string The nav type name
+ */
+if ( !function_exists( 'ucfwp_get_nav_type' ) ) {
+	function ucfwp_get_nav_type() {
+		$nav_type = '';
+
+		// Fall back to the ucf.edu primary navigation if a
+		// header menu is not set.
+		if ( ! has_nav_menu( 'header-menu' ) ) {
+			$nav_type = 'mainsite';
+		}
+
+		return apply_filters( 'ucfwp_get_nav_type', $nav_type );
+	}
+}
+
+
+/**
+ * Returns HTML markup for the primary site navigation.
+ *
+ * @author Jo Dickson
+ * @since 0.0.0
+ * @param bool $image Whether or not a media background is present in the page header.
+ * @return string Nav HTML
+ **/
+if ( !function_exists( 'ucfwp_get_nav_markup' ) ) {
+	function ucfwp_get_nav_markup( $image=true ) {
+		$retval = '';
+		$template_part_name = ucfwp_get_nav_type();
+
+		set_query_var( 'ucfwp_image_behind_nav', $image );
+
+		ob_start();
+		get_template_part( ucfwp_get_template_part_slug( 'nav' ), $template_part_name );
+		$retval = ob_get_clean();
+
+		return apply_filters( 'ucfwp_get_nav_markup', $retval );
+	}
+}
+
+
+/**
+ * Returns subnavigation markup for the current object.
+ *
+ * @author Jo Dickson
+ * @since 0.0.0
+ * @return string HTML for the page header
+ **/
+if ( !function_exists( 'ucfwp_get_subnav_markup' ) ) {
+	function ucfwp_get_subnav_markup() {
+		$obj = ucfwp_get_queried_object();
+		$include_subnav = get_field( 'page_header_include_subnav', $obj );
+
+		if ( class_exists( 'Section_Menus_Common' ) && $include_subnav ) {
+			return do_shortcode( '[section-menu]' );
+		}
+	}
+}
+
+
+/**
+ * Nav walker class compatible with BS4-alpha/Athena Framework
+ */
 if ( !class_exists( 'bs4Navwalker' ) ) {
 
 	/**

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -5,7 +5,7 @@
  * The value returned will represent an equivalent template part's name.
  *
  * @author Jo Dickson
- * @since TODO
+ * @since 0.4.0
  * @return string The nav type name
  */
 if ( !function_exists( 'ucfwp_get_nav_type' ) ) {

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -93,7 +93,7 @@ function ucfwp_is_content_empty($str) {
  * Ideally in a next major release, this function will be replaceable
  * with get_template_part().
  *
- * @since TODO
+ * @since 0.4.0
  * @author Jo Dickson
  * @param string $template_part_slug The template part slug to fetch
  * @param string $template_part_name The template part name to fetch
@@ -146,7 +146,7 @@ function _ucfwp_get_template_part( $template_part_slug, $template_part_name ) {
  * $slug param in get_template_part().
  *
  * @author Jo Dickson
- * @since TODO
+ * @since 0.4.0
  * @param string $subpath An optional subdirectory within the template parts directory
  * @return string The desired template part slug (for this theme and child themes)
  */
@@ -167,7 +167,7 @@ if ( ! function_exists( 'ucfwp_get_template_part_slug' ) ) {
  *
  * @see https://codex.wordpress.org/Function_Reference/get_queried_object
  *
- * @since TODO
+ * @since 0.4.0
  * @author Jo Dickson
  * @return mixed The queried object, or null if no valid object was queried
  */

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -162,6 +162,8 @@ if ( ! function_exists( 'ucfwp_get_template_part_slug' ) ) {
 
 /**
  * Wrapper for get_queried_object() with opinionated overrides for this theme.
+ * Sets a `ucfwp_obj` query var on the global $wp_query object for fast
+ * reference in subsequent requests for the queried object.
  *
  * @see https://codex.wordpress.org/Function_Reference/get_queried_object
  *
@@ -170,6 +172,17 @@ if ( ! function_exists( 'ucfwp_get_template_part_slug' ) ) {
  * @return mixed The queried object, or null if no valid object was queried
  */
 function ucfwp_get_queried_object() {
+	// If ucfwp_obj is already a set query param, return it.
+	// Note that a set value may still be null, but valid.
+	//
+	// We reference $wp_query here directly because we have no
+	// other means of determining the difference between an
+	// unset value and a set, but empty/null, value.
+	global $wp_query;
+	if ( $wp_query && array_key_exists( 'ucfwp_obj', $wp_query->query_vars ) ) {
+		return $wp_query->query_vars['ucfwp_obj'];
+	}
+
 	$obj = get_queried_object();
 
 	if ( !$obj && is_404() ) {
@@ -178,6 +191,10 @@ function ucfwp_get_queried_object() {
 			$obj = $page;
 		}
 	}
+
+	// Store as a query var on $wp_query for reference in
+	// subsequent queried object requests:
+	set_query_var( 'ucfwp_obj', $obj );
 
 	return $obj;
 }

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -95,6 +95,7 @@ function ucfwp_is_content_empty($str) {
  *
  * @since 0.4.0
  * @author Jo Dickson
+ * @internal
  * @param string $template_part_slug The template part slug to fetch
  * @param string $template_part_name The template part name to fetch
  */

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -107,7 +107,7 @@ function _ucfwp_get_template_part( $template_part_slug, $template_part_name ) {
 	$images = ucfwp_get_header_images( $obj );
 
 	switch ( $template_part_slug ) {
-		case 'template-parts/header':
+		case ucfwp_get_template_part_slug( 'header' ):
 			switch ( $template_part_name ) {
 				case '':
 					$shim_retval = ucfwp_get_header_default_markup( $obj );
@@ -118,7 +118,7 @@ function _ucfwp_get_template_part( $template_part_slug, $template_part_name ) {
 				default:
 					break;
 			}
-		case 'template-parts/header_content':
+		case ucfwp_get_template_part_slug( 'header_content' ):
 			switch ( $template_part_name ) {
 				case 'title_subtitle':
 					$shim_retval = ucfwp_get_header_content_title_subtitle( $obj );

--- a/template-parts/footer.php
+++ b/template-parts/footer.php
@@ -1,0 +1,40 @@
+<?php
+if (
+	is_active_sidebar( 'footer-col-1' )
+	|| is_active_sidebar( 'footer-col-2' )
+	|| is_active_sidebar( 'footer-col-3' )
+	|| is_active_sidebar( 'footer-col-4' )
+):
+?>
+<footer class="site-footer bg-inverse pt-4 py-md-5">
+	<div class="container mt-4">
+		<div class="row">
+
+		<?php if ( is_active_sidebar( 'footer-col-1' ) ): ?>
+			<section class="col-12 col-lg">
+				<?php dynamic_sidebar( 'footer-col-1' ); ?>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( is_active_sidebar( 'footer-col-2' ) ): ?>
+			<section class="col-12 col-lg">
+				<?php dynamic_sidebar( 'footer-col-2' ); ?>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( is_active_sidebar( 'footer-col-3' ) ): ?>
+			<section class="col-12 col-lg">
+				<?php dynamic_sidebar( 'footer-col-3' ); ?>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( is_active_sidebar( 'footer-col-4' ) ): ?>
+			<section class="col-12 col-lg">
+				<?php dynamic_sidebar( 'footer-col-4' ); ?>
+			</section>
+		<?php endif; ?>
+
+		</div>
+	</div>
+</footer>
+<?php endif; ?>

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -1,5 +1,5 @@
 <?php
-$obj        = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$obj        = ucfwp_get_queried_object();
 $videos     = ucfwp_get_header_videos( $obj );
 $images     = ucfwp_get_header_images( $obj );
 $video_loop = get_field( 'page_header_video_loop', $obj );

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -35,7 +35,7 @@ $exclude_nav         = get_field( 'page_header_exclude_nav', $obj );
 	?>
 	<div class="header-content">
 		<div class="header-content-flexfix">
-			<?php get_template_part( ucfwp_get_template_part_slug( 'header_content' ), $header_content_type ); ?>
+			<?php _ucfwp_get_template_part( ucfwp_get_template_part_slug( 'header_content' ), $header_content_type ); ?>
 		</div>
 	</div>
 

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -1,0 +1,50 @@
+<?php
+$obj        = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$videos     = ucfwp_get_header_videos( $obj );
+$images     = ucfwp_get_header_images( $obj );
+$video_loop = get_field( 'page_header_video_loop', $obj );
+$header_content_type = ucfwp_get_header_content_type( $obj );
+$header_height       = get_field( 'page_header_height', $obj );
+$exclude_nav         = get_field( 'page_header_exclude_nav', $obj );
+?>
+
+<div class="header-media <?php echo $header_height; ?> mb-0 d-flex flex-column">
+	<div class="header-media-background-wrap">
+		<div class="header-media-background media-background-container">
+			<?php
+			// Display the media background (video + picture)
+
+			if ( $videos ) {
+				echo ucfwp_get_media_background_video( $videos, $video_loop );
+			}
+			if ( $images ) {
+				$bg_image_srcs = ucfwp_get_header_media_picture_srcs( $header_height, $images );
+				echo ucfwp_get_media_background_picture( $bg_image_srcs );
+			}
+			?>
+		</div>
+	</div>
+
+	<?php
+	// Display the site nav
+	if ( !$exclude_nav ) { echo ucfwp_get_nav_markup(); }
+	?>
+
+	<?php
+	// Display the inner header contents
+	?>
+	<div class="header-content">
+		<div class="header-content-flexfix">
+			<?php get_template_part( ucfwp_get_template_part_slug( 'header_content' ), $header_content_type ); ?>
+		</div>
+	</div>
+
+	<?php
+	// Print a spacer div for headers with background videos (to make
+	// control buttons accessible), and for headers showing a standard
+	// title/subtitle to push them up a bit
+	if ( $videos || $header_content_type === 'title_subtitle' ):
+	?>
+	<div class="header-media-controlfix"></div>
+	<?php endif; ?>
+</div>

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -35,7 +35,7 @@ $exclude_nav         = get_field( 'page_header_exclude_nav', $obj );
 	?>
 	<div class="header-content">
 		<div class="header-content-flexfix">
-			<?php _ucfwp_get_template_part( ucfwp_get_template_part_slug( 'header_content' ), $header_content_type ); ?>
+			<?php echo ucfwp_get_header_content_markup(); ?>
 		</div>
 	</div>
 

--- a/template-parts/header.php
+++ b/template-parts/header.php
@@ -6,4 +6,4 @@ $exclude_nav         = get_field( 'page_header_exclude_nav', $obj );
 
 <?php if ( ! $exclude_nav ) { echo ucfwp_get_nav_markup( false ); } ?>
 
-<?php get_template_part( ucfwp_get_template_part_slug( 'header_content' ), $header_content_type ); ?>
+<?php _ucfwp_get_template_part( ucfwp_get_template_part_slug( 'header_content' ), $header_content_type ); ?>

--- a/template-parts/header.php
+++ b/template-parts/header.php
@@ -1,0 +1,9 @@
+<?php
+$obj                 = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$header_content_type = ucfwp_get_header_content_type( $obj );
+$exclude_nav         = get_field( 'page_header_exclude_nav', $obj );
+?>
+
+<?php if ( ! $exclude_nav ) { echo ucfwp_get_nav_markup( false ); } ?>
+
+<?php get_template_part( ucfwp_get_template_part_slug( 'header_content' ), $header_content_type ); ?>

--- a/template-parts/header.php
+++ b/template-parts/header.php
@@ -1,9 +1,8 @@
 <?php
-$obj                 = ucfwp_get_queried_object();
-$header_content_type = ucfwp_get_header_content_type( $obj );
-$exclude_nav         = get_field( 'page_header_exclude_nav', $obj );
+$obj         = ucfwp_get_queried_object();
+$exclude_nav = get_field( 'page_header_exclude_nav', $obj );
 ?>
 
 <?php if ( ! $exclude_nav ) { echo ucfwp_get_nav_markup( false ); } ?>
 
-<?php _ucfwp_get_template_part( ucfwp_get_template_part_slug( 'header_content' ), $header_content_type ); ?>
+<?php echo ucfwp_get_header_content_markup(); ?>

--- a/template-parts/header.php
+++ b/template-parts/header.php
@@ -1,5 +1,5 @@
 <?php
-$obj                 = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$obj                 = ucfwp_get_queried_object();
 $header_content_type = ucfwp_get_header_content_type( $obj );
 $exclude_nav         = get_field( 'page_header_exclude_nav', $obj );
 ?>

--- a/template-parts/header_content-custom.php
+++ b/template-parts/header_content-custom.php
@@ -1,0 +1,8 @@
+<?php
+$obj     = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$content = get_field( 'page_header_content', $obj ) ?: '';
+?>
+
+<div class="header-content-inner">
+	<?php echo $content; ?>
+</div>

--- a/template-parts/header_content-custom.php
+++ b/template-parts/header_content-custom.php
@@ -1,5 +1,5 @@
 <?php
-$obj     = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$obj     = ucfwp_get_queried_object();
 $content = get_field( 'page_header_content', $obj ) ?: '';
 ?>
 

--- a/template-parts/header_content-title_subtitle.php
+++ b/template-parts/header_content-title_subtitle.php
@@ -1,5 +1,5 @@
 <?php
-$obj           = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$obj           = ucfwp_get_queried_object();
 $title         = ucfwp_get_header_title( $obj );
 $subtitle      = ucfwp_get_header_subtitle( $obj );
 $h1            = ucfwp_get_header_h1_option( $obj );

--- a/template-parts/header_content-title_subtitle.php
+++ b/template-parts/header_content-title_subtitle.php
@@ -1,0 +1,25 @@
+<?php
+$obj           = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$title         = ucfwp_get_header_title( $obj );
+$subtitle      = ucfwp_get_header_subtitle( $obj );
+$h1            = ucfwp_get_header_h1_option( $obj );
+$h1_elem       = ( is_home() || is_front_page() ) ? 'h2' : 'h1'; // name is misleading but we need to override this elem on the homepage
+$title_elem    = ( $h1 === 'title' ) ? $h1_elem : 'span';
+$subtitle_elem = ( $h1 === 'subtitle' ) ? $h1_elem : 'span';
+?>
+
+<?php if ( $title ): ?>
+	<div class="header-content-inner align-self-start pt-4 pt-sm-0 align-self-sm-center">
+		<div class="container">
+			<div class="d-inline-block bg-primary-t-1">
+				<<?php echo $title_elem; ?> class="header-title"><?php echo $title; ?></<?php echo $title_elem; ?>>
+			</div>
+			<?php if ( $subtitle ) : ?>
+			<div class="clearfix"></div>
+			<div class="d-inline-block bg-inverse">
+				<<?php echo $subtitle_elem; ?> class="header-subtitle"><?php echo $subtitle; ?></<?php echo $subtitle_elem; ?>>
+			</div>
+			<?php endif; ?>
+		</div>
+	</div>
+<?php endif; ?>

--- a/template-parts/header_content.php
+++ b/template-parts/header_content.php
@@ -1,5 +1,5 @@
 <?php
-$obj              = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$obj              = ucfwp_get_queried_object();
 $title            = ucfwp_get_header_title( $obj );
 $subtitle         = ucfwp_get_header_subtitle( $obj );
 $h1               = ucfwp_get_header_h1_option( $obj );

--- a/template-parts/header_content.php
+++ b/template-parts/header_content.php
@@ -1,0 +1,25 @@
+<?php
+$obj              = get_query_var( 'ucfwp_obj', ucfwp_get_queried_object() );
+$title            = ucfwp_get_header_title( $obj );
+$subtitle         = ucfwp_get_header_subtitle( $obj );
+$h1               = ucfwp_get_header_h1_option( $obj );
+$h1_elem          = ( is_home() || is_front_page() ) ? 'h2' : 'h1'; // name is misleading but we need to override this elem on the homepage
+$title_elem       = ( $h1 === 'title' ) ? $h1_elem : 'span';
+$subtitle_elem    = ( $h1 === 'subtitle' ) ? $h1_elem : 'p';
+$title_classes    = 'h1 d-block mt-3 mt-sm-4 mt-md-5 mb-2 mb-md-3';
+$subtitle_classes = 'lead mb-2 mb-md-3';
+?>
+
+<?php if ( $title ): ?>
+<div class="container">
+	<<?php echo $title_elem; ?> class="<?php echo $title_classes; ?>">
+		<?php echo $title; ?>
+	</<?php echo $title_elem; ?>>
+
+	<?php if ( $subtitle ): ?>
+		<<?php echo $subtitle_elem; ?> class="<?php echo $subtitle_classes; ?>">
+			<?php echo $subtitle; ?>
+		</<?php echo $subtitle_elem; ?>>
+	<?php endif; ?>
+</div>
+<?php endif; ?>

--- a/template-parts/nav-mainsite.php
+++ b/template-parts/nav-mainsite.php
@@ -1,0 +1,46 @@
+<?php
+global $wp_customize;
+$image          = (bool) get_query_var( 'ucfwp_image_behind_nav', false );
+$customizing    = isset( $wp_customize );
+$feed_url       = get_theme_mod( 'mainsite_nav_url' ) ?: UCFWP_MAINSITE_NAV_URL;
+$transient_name = 'ucfwp_mainsite_nav_json';
+$result         = get_transient( $transient_name );
+
+if ( empty( $result ) || $customizing ) {
+	// Try fetching the theme mod value or default
+	$result = ucfwp_fetch_json( $feed_url );
+
+	// If the theme mod value failed and it's not what we set as our
+	// default, try again using the default
+	if ( !$result && $feed_url !== UCFWP_MAINSITE_NAV_URL ) {
+		$result = ucfwp_fetch_json( UCFWP_MAINSITE_NAV_URL );
+	}
+
+	if ( ! $customizing ) {
+		set_transient( $transient_name, $result, (60 * 60 * 24) );
+	}
+}
+
+if ( $result ):
+	$menu = $result;
+?>
+	<nav class="navbar navbar-toggleable-md navbar-mainsite py-2<?php echo $image ? ' py-sm-4 navbar-inverse header-gradient' : ' navbar-inverse bg-inverse-t-3 py-lg-4'; ?>" role="navigation" aria-label="Site navigation">
+		<div class="container">
+			<button class="navbar-toggler ml-auto collapsed" type="button" data-toggle="collapse" data-target="#header-menu" aria-controls="header-menu" aria-expanded="false" aria-label="Toggle navigation">
+				<span class="navbar-toggler-text">Navigation</span>
+				<span class="navbar-toggler-icon"></span>
+			</button>
+			<div class="collapse navbar-collapse" id="header-menu">
+				<ul id="menu-header-menu" class="nav navbar-nav nav-fill">
+					<?php foreach ( $menu->items as $item ): ?>
+					<li class="menu-item nav-item">
+						<a href="<?php echo $item->url; ?>" target="<?php echo $item->target; ?>" class="nav-link">
+							<?php echo $item->title; ?>
+						</a>
+					</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+		</div>
+	</nav>
+<?php endif; ?>

--- a/template-parts/nav.php
+++ b/template-parts/nav.php
@@ -1,0 +1,32 @@
+<?php
+$image      = (bool) get_query_var( 'ucfwp_image_behind_nav', false );
+$title_elem = ( is_home() || is_front_page() ) ? 'h1' : 'span';
+?>
+
+<nav class="navbar navbar-toggleable-md navbar-custom<?php echo $image ? ' py-2 py-sm-4 navbar-inverse header-gradient' : ' navbar-inverse bg-inverse-t-3'; ?>" role="navigation" aria-label="Site navigation">
+	<div class="container d-flex flex-row flex-nowrap justify-content-between">
+		<<?php echo $title_elem; ?> class="mb-0">
+			<a class="navbar-brand mr-lg-5" href="<?php echo get_home_url(); ?>"><?php echo bloginfo( 'name' ); ?></a>
+		</<?php echo $title_elem; ?>>
+		<button class="navbar-toggler ml-auto align-self-start collapsed" type="button" data-toggle="collapse" data-target="#header-menu" aria-controls="header-menu" aria-expanded="false" aria-label="Toggle navigation">
+			<span class="navbar-toggler-text">Navigation</span>
+			<span class="navbar-toggler-icon"></span>
+		</button>
+		<?php
+		$container_class = 'collapse navbar-collapse';
+		if ( !$image ) {
+			$container_class = $container_class . ' align-self-lg-stretch';
+		}
+		wp_nav_menu( array(
+			'container'       => 'div',
+			'container_class' => $container_class,
+			'container_id'    => 'header-menu',
+			'depth'           => 2,
+			'fallback_cb'     => 'bs4Navwalker::fallback',
+			'menu_class'      => 'nav navbar-nav ml-md-auto',
+			'theme_location'  => 'header-menu',
+			'walker'          => new bs4Navwalker()
+		) );
+		?>
+	</div>
+</nav>


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Refactors how header, nav, and footer markup is loaded to use template parts, via `get_template_part()`.  Most header and header markup functions have been marked as deprecated and slated for removal in the next major release of the UCF WordPress Theme (v1.0.0).  

The theme will now support 4 kinds of template parts out of the box: **"header"**, **"header_content"**, **"nav"**, and **"footer"**.  Of these, the following types are included:

header
- **""** _(default type - used when no header image/video is available)_
- **"media"**

header_content
- **""** _(default type - displays a plain page title, and subtitle if available)_
- **"title_subtitle"** _(stylized gold title/black subtitle)_
- **"custom"**

nav
- **""** _(default type)_
- **"mainsite"** _(fallback nav when no header menu has been assigned)_

footer
- **""** _(default type)_

The naming of the default template parts (empty string) follows the convention that's expected for [`get_template_part()`](https://developer.wordpress.org/reference/functions/get_template_part/).

Whichever template part gets used on a given page/post can be overridden in a child theme using one of these new hooks:  `ucfwp_get_header_type`, `ucfwp_get_header_content_type`, `ucfwp_get_nav_type`, `ucfwp_get_footer_type`.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current logic behind page headers is very monolithic and difficult to override in child themes if you want any extra types of headers besides the default or media background headers.  This update transitions to using `get_template_part()` instead, which allows child themes to easily override markup by defining a custom template, just like you'd do with other templates in the theme.

Also resolves #40.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
** Will add a task to update documentation when this PR has been approved.
