### PR TITLE
Default nav template - conditional mobile toggle btn

### DIFF
--- a/template-parts/nav.php
+++ b/template-parts/nav.php
@@ -1,6 +1,23 @@
 <?php
 $image      = (bool) get_query_var( 'ucfwp_image_behind_nav', false );
 $title_elem = ( is_home() || is_front_page() ) ? 'h1' : 'span';
+
+$menu_container_class = 'collapse navbar-collapse';
+if ( ! $image ) {
+	$menu_container_class = $menu_container_class . ' align-self-lg-stretch';
+}
+
+$menu = wp_nav_menu( array(
+	'container'       => 'div',
+	'container_class' => $menu_container_class,
+	'container_id'    => 'header-menu',
+	'depth'           => 2,
+	'echo'            => false,
+	'fallback_cb'     => 'bs4Navwalker::fallback',
+	'menu_class'      => 'nav navbar-nav ml-md-auto',
+	'theme_location'  => 'header-menu',
+	'walker'          => new bs4Navwalker()
+) );
 ?>
 
 <nav class="navbar navbar-toggleable-md navbar-custom<?php echo $image ? ' py-2 py-sm-4 navbar-inverse header-gradient' : ' navbar-inverse bg-inverse-t-3'; ?>" role="navigation" aria-label="Site navigation">
@@ -8,25 +25,14 @@ $title_elem = ( is_home() || is_front_page() ) ? 'h1' : 'span';
 		<<?php echo $title_elem; ?> class="mb-0">
 			<a class="navbar-brand mr-lg-5" href="<?php echo get_home_url(); ?>"><?php echo bloginfo( 'name' ); ?></a>
 		</<?php echo $title_elem; ?>>
+
+		<?php if ( $menu ): ?>
 		<button class="navbar-toggler ml-auto align-self-start collapsed" type="button" data-toggle="collapse" data-target="#header-menu" aria-controls="header-menu" aria-expanded="false" aria-label="Toggle navigation">
 			<span class="navbar-toggler-text">Navigation</span>
 			<span class="navbar-toggler-icon"></span>
 		</button>
-		<?php
-		$container_class = 'collapse navbar-collapse';
-		if ( !$image ) {
-			$container_class = $container_class . ' align-self-lg-stretch';
-		}
-		wp_nav_menu( array(
-			'container'       => 'div',
-			'container_class' => $container_class,
-			'container_id'    => 'header-menu',
-			'depth'           => 2,
-			'fallback_cb'     => 'bs4Navwalker::fallback',
-			'menu_class'      => 'nav navbar-nav ml-md-auto',
-			'theme_location'  => 'header-menu',
-			'walker'          => new bs4Navwalker()
-		) );
-		?>
+
+		<?php echo $menu; ?>
+		<?php endif; ?>
 	</div>
 </nav>


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Updated default nav template to only display the mobile toggle button if a menu is set.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes bug in the default nav template part where a toggle button would be displayed regardless of whether or not a menu is assigned to the `header-menu` location.

While this problem wouldn't be present in the UCF WP Theme on its own, if a child theme were to override the `ucfwp_get_nav_type` hook to always return the default nav template, the toggle button would always be displayed, and would be non-functional if no `header-menu` were assigned.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
