### PR TITLE
Do not display header element if custom content is empty

### DIFF
--- a/header.php
+++ b/header.php
@@ -10,7 +10,7 @@
 		<?php do_action( 'after_body_open' ); ?>
 		
 		<?php if ( ucfwp_check_header_custom_content() ) : ?>
-		<header class="site-header test">
+		<header class="site-header">
 			<?php echo ucfwp_get_header_markup(); ?>
 		</header>
 		<?php endif; ?>

--- a/header.php
+++ b/header.php
@@ -8,10 +8,12 @@
 		<div id="ucfhb"></div>
 
 		<?php do_action( 'after_body_open' ); ?>
-
-		<header class="site-header">
+		
+		<?php if ( ucfwp_check_header_custom_content() ) : ?>
+		<header class="site-header test">
 			<?php echo ucfwp_get_header_markup(); ?>
 		</header>
+		<?php endif; ?>
 
 		<main class="site-main">
 			<?php echo ucfwp_get_subnav_markup(); ?>

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -342,8 +342,8 @@ if ( !function_exists( 'ucfwp_check_header_custom_content' ) ) {
 
 		if ( $content_type === "custom" && empty( $custom_content ) ) {
 			return false;
-		} else {
-			return true;
 		}
+		
+		return true;
 	}
 }

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -324,3 +324,26 @@ if ( !function_exists( 'ucfwp_get_header_content_markup' ) ) {
 		return apply_filters( 'ucfwp_get_header_content_markup', $retval, $obj );
 	}
 }
+
+
+/**
+ * Checks whether the header's custom content is empty.
+ *
+ * @author Cadie Brown
+ * @since 0.5.0
+ * @return bool Boolean value for header content check
+ */
+if ( !function_exists( 'ucfwp_check_header_custom_content' ) ) {
+	function ucfwp_check_header_custom_content() {
+		$obj = ucfwp_get_queried_object();
+
+		$content_type   = get_field( 'page_header_content_type', $obj ) ?: '';
+		$custom_content = get_field( 'page_header_content', $obj ) ?: '';
+
+		if ( $content_type === "custom" && empty( $custom_content ) ) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
**Description**
See title.

**Motivation and Context**
This ensures that when the header options are set to custom content and the content is empty, an empty `<header>` tag is not displayed. 

**How Has This Been Tested?**
Updates viewable in dev.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
