### PR TITLE
Responsive image max srcset size

### DIFF
--- a/includes/galleries.php
+++ b/includes/galleries.php
@@ -207,7 +207,7 @@ function ucfwp_gallery_display_thumbnails( $gallery_id, $attachments, $attr ) {
 					</a>
 					<?php endif; ?>
 
-					<?php if ( $attr['thumbnail_captions'] ): ?>
+					<?php if ( filter_var( $attr['thumbnail_captions'], FILTER_VALIDATE_BOOLEAN ) ): ?>
 					<figcaption class="figure-caption">
 						<?php echo $excerpt; ?>
 					</figcaption>

--- a/includes/galleries.php
+++ b/includes/galleries.php
@@ -201,7 +201,7 @@ function ucfwp_gallery_display_thumbnails( $gallery_id, $attachments, $attr ) {
 					<a href="<?php echo $img_url_full; ?>">
 					<?php endif; ?>
 
-						<?php echo wp_get_attachment_image( $attachment->ID, $attr['size'], false, array( 'class' => 'img-fluid' ) ); ?>
+						<?php echo ucfwp_get_attachment_image( $attachment->ID, $attr['size'], false, array( 'class' => 'img-fluid' ) ); ?>
 
 					<?php if ( $attr['link'] !== 'none' ): ?>
 					</a>

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -37,12 +37,25 @@ function ucfwp_get_attachment_src_by_size( $id, $size ) {
  */
 function ucfwp_get_attachment_image( $attachment_id, $size='thumbnail', $icon=false, $attr='' ) {
 	$use_filter = true;
-	if ( ! $size || $size === 'full' || ( is_array( $size ) && intval( $size[0] ) === 0 ) ) {
+	$max_srcset_width = 0;
+
+	if ( is_array( $size ) ) {
+		$max_srcset_width = intval( $size[0] );
+	}
+	else {
+		$max_srcset_width = intval( get_option( $size . '_size_w' ) );
+	}
+
+	if (
+		! $max_srcset_width
+		|| ! $size
+		|| $size === 'full'
+	) {
 		$use_filter = false;
 	}
 
-	$custom_filter = function( $width ) use ( $thumb_size_dims ) {
-		return $thumb_size_dims[0];
+	$custom_filter = function( $width ) use ( $max_srcset_width ) {
+		return $max_srcset_width;
 	};
 
 	if ( $use_filter ) {

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -23,6 +23,43 @@ function ucfwp_get_attachment_src_by_size( $id, $size ) {
 
 
 /**
+ * Shim for `wp_get_attachment_image()` that forces the maximum
+ * width in the image's generated srcset to not exceed the requested
+ * image dimensions.
+ *
+ * @since 0.5.0
+ * @author Jo Dickson
+ * @param int $attachment_id Image attachment ID.
+ * @param mixed $size String or array representing an image size
+ * @param bool $icon (Optional) Whether the image should be treated as an icon
+ * @param mixed $attr String or array of attributes for the image markup
+ * @return string HTML img element or empty string on failure.
+ */
+function ucfwp_get_attachment_image( $attachment_id, $size='thumbnail', $icon=false, $attr='' ) {
+	$use_filter = true;
+	if ( ! $size || $size === 'full' || ( is_array( $size ) && intval( $size[0] ) === 0 ) ) {
+		$use_filter = false;
+	}
+
+	$custom_filter = function( $width ) use ( $thumb_size_dims ) {
+		return $thumb_size_dims[0];
+	};
+
+	if ( $use_filter ) {
+		add_filter( 'max_srcset_image_width', $custom_filter );
+	}
+
+	$image = wp_get_attachment_image( $attachment_id, $size, $icon, $attr );
+
+	if ( $use_filter ) {
+		remove_filter( 'max_srcset_image_width', $custom_filter );
+	}
+
+	return $image;
+}
+
+
+/**
  * Returns a JSON object from the provided URL.  Detects undesirable status
  * codes and returns false if the response doesn't look valid.
  *

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -37,14 +37,7 @@ function ucfwp_get_attachment_src_by_size( $id, $size ) {
  */
 function ucfwp_get_attachment_image( $attachment_id, $size='thumbnail', $icon=false, $attr='' ) {
 	$use_filter = true;
-	$max_srcset_width = 0;
-
-	if ( is_array( $size ) ) {
-		$max_srcset_width = intval( $size[0] );
-	}
-	else {
-		$max_srcset_width = intval( get_option( $size . '_size_w' ) );
-	}
+	$max_srcset_width = is_array( $size ) ? intval( $size[0] ) : intval( get_option( $size . '_size_w' ) );
 
 	if (
 		! $max_srcset_width


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds a wrapper function for `wp_get_attachment_image()` called `ucfwp_get_attachment_image()`, which forces the maximum width in the image's generated `srcset` to not exceed the requested image dimensions.

Also adds a quick fix for the `thumbnail_captions` attribute on our `[gallery]` shortcode overrides, since it wasn't properly getting filtered as a boolean value before.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Because WordPress actually hard-codes a maximum width of 1600px for `srcset` values generated by `wp_calculate_image_srcset()` (https://core.trac.wordpress.org/browser/tags/5.1.1/src/wp-includes/media.php#L1115), a `srcset` can potentially include larger image sizes than intended when a specific thumbnail size is passed in to `wp_get_attachment_image()`, resulting in the browser unintentionally downloading bigger images at larger screen sizes.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation. ** Note added to document this new function (and other utility functions) in #41.
- [ ] I have updated the documentation accordingly.
