### PR TITLE
Remove title attributes that conflict with decorative images

### DIFF
--- a/includes/person-functions.php
+++ b/includes/person-functions.php
@@ -21,7 +21,7 @@ if ( ! function_exists( 'ucfwp_get_person_thumbnail' ) ) {
 		if ( $thumbnail ):
 	?>
 		<div class="media-background-container person-photo mx-auto <?php echo $css_classes; ?>">
-			<img src="<?php echo $thumbnail; ?>" alt="" title="<?php echo $post->post_title; ?>" class="media-background object-fit-cover">
+			<img src="<?php echo $thumbnail; ?>" alt="" class="media-background object-fit-cover">
 		</div>
 	<?php
 		endif;


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Removes the `title` attribute from decorative images in person post lists.  Should be the only instance in the theme where we explicitly include a title attribute on a generated image.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Apparently including a title attribute that has a value, along with an empty `alt` attribute, violates https://www.w3.org/TR/WCAG20-TECHS/H67.html.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
