### PR TITLE
Added missing breaks to outer switch case in _ucfwp_get_template_part

### DIFF
--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -198,6 +198,7 @@ function _ucfwp_get_template_part( $template_part_slug, $template_part_name ) {
 				default:
 					break;
 			}
+			break;
 		case ucfwp_get_template_part_slug( 'header_content' ):
 			switch ( $template_part_name ) {
 				case 'title_subtitle':
@@ -209,6 +210,7 @@ function _ucfwp_get_template_part( $template_part_slug, $template_part_name ) {
 				default:
 					break;
 			}
+			break;
 		default:
 			break;
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds missing `break`s in the outer switch cases in `_ucfwp_get_template_part()`.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fix was originally included in #69, but since that branch's changes have been reverted, the fix needs to be re-merged in separately.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
