### PR TITLE
Force absolute includes in functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,47 +1,50 @@
 <?php
+define( 'UCFWP_THEME_DIR', trailingslashit( get_template_directory() ) );
+
+
 // Deprecated functions
-include_once 'includes/deprecated.php';
+include_once UCFWP_THEME_DIR . 'includes/deprecated.php';
 
 // Activation checks
-include_once 'includes/activate.php';
+include_once UCFWP_THEME_DIR . 'includes/activate.php';
 
 // Theme foundation
-include_once 'includes/utilities.php';
-include_once 'includes/config.php';
-include_once 'includes/meta.php';
-include_once 'includes/galleries.php';
-include_once 'includes/media-backgrounds.php';
-include_once 'includes/nav-functions.php';
-include_once 'includes/header-functions.php';
-include_once 'includes/footer-functions.php';
-include_once 'includes/pagination-functions.php';
+include_once UCFWP_THEME_DIR . 'includes/utilities.php';
+include_once UCFWP_THEME_DIR . 'includes/config.php';
+include_once UCFWP_THEME_DIR . 'includes/meta.php';
+include_once UCFWP_THEME_DIR . 'includes/galleries.php';
+include_once UCFWP_THEME_DIR . 'includes/media-backgrounds.php';
+include_once UCFWP_THEME_DIR . 'includes/nav-functions.php';
+include_once UCFWP_THEME_DIR . 'includes/header-functions.php';
+include_once UCFWP_THEME_DIR . 'includes/footer-functions.php';
+include_once UCFWP_THEME_DIR . 'includes/pagination-functions.php';
 
 // Plugin extras/overrides
 
 if ( class_exists( 'UCF_People_PostType' ) ) {
-	include_once 'includes/person-functions.php';
+	include_once UCFWP_THEME_DIR . 'includes/person-functions.php';
 }
 
 if ( class_exists( 'UCF_Section_Common' ) ) {
-	include_once 'includes/section-functions.php';
+	include_once UCFWP_THEME_DIR . 'includes/section-functions.php';
 }
 
 if ( class_exists( 'UCF_Alert_Common' ) ) {
-	include_once 'includes/ucf-alert-functions.php';
+	include_once UCFWP_THEME_DIR . 'includes/ucf-alert-functions.php';
 }
 
 if ( class_exists( 'UCF_Pegasus_List_Common' ) ) {
-	include_once 'includes/pegasus-list-functions.php';
+	include_once UCFWP_THEME_DIR . 'includes/pegasus-list-functions.php';
 }
 
 if ( class_exists( 'UCF_Events_Common' ) ) {
-	include_once 'includes/events-functions.php';
+	include_once UCFWP_THEME_DIR . 'includes/events-functions.php';
 }
 
 if ( class_exists( 'UCF_Acad_Cal_Common' ) ) {
-	include_once 'includes/acad-cal-functions.php';
+	include_once UCFWP_THEME_DIR . 'includes/acad-cal-functions.php';
 }
 
 if ( class_exists( 'UCF_Post_List_Common' ) ) {
-	include_once 'includes/post-list-functions.php';
+	include_once UCFWP_THEME_DIR . 'includes/post-list-functions.php';
 }


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For whatever reason, relative `include`s aren't working as expected, and are attempting to (and successfully) loading core WP files instead of theme-specific files when found.  This is causing a fatal error in WP 5.3 with the theme's `includes/deprecated.php` import.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested locally against WP 5.3.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
