### PR TITLE
KSES filter updates

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -247,112 +247,115 @@ if ( function_exists( 'athena_sc_tinymce_init' ) ) {
 /**
  * Allow special tags in post bodies that would get stripped otherwise for most users.
  * Modifies $allowedposttags defined in wp-includes/kses.php
- *
- * http://wordpress.org/support/topic/div-ids-being-stripped-out
- * http://wpquicktips.wordpress.com/2010/03/12/how-to-change-the-allowed-html-tags-for-wordpress/
  **/
-$allowedposttags['input'] = array(
-	'type' => array(),
-	'value' => array(),
-	'id' => array(),
-	'name' => array(),
-	'class' => array()
-);
-$allowedposttags['select'] = array(
-	'id' => array(),
-	'name' => array()
-);
-$allowedposttags['option'] = array(
-	'id' => array(),
-	'name' => array(),
-	'value' => array()
-);
-$allowedposttags['iframe'] = array(
-	'type' => array(),
-	'value' => array(),
-	'id' => array(),
-	'name' => array(),
-	'class' => array(),
-	'src' => array(),
-	'height' => array(),
-	'width' => array(),
-	'allowfullscreen' => array(),
-	'frameborder' => array()
-);
-$allowedposttags['object'] = array(
-	'height' => array(),
-	'width' => array()
-);
+function ucfwp_kses_allowed_html( $tags, $context ) {
+	$tags['input'] = array(
+		'type' => array(),
+		'value' => array(),
+		'id' => array(),
+		'name' => array(),
+		'class' => array()
+	);
+	$tags['select'] = array(
+		'id' => array(),
+		'name' => array()
+	);
+	$tags['option'] = array(
+		'id' => array(),
+		'name' => array(),
+		'value' => array()
+	);
+	$tags['iframe'] = array(
+		'type' => array(),
+		'value' => array(),
+		'id' => array(),
+		'name' => array(),
+		'class' => array(),
+		'src' => array(),
+		'height' => array(),
+		'width' => array(),
+		'allowfullscreen' => array(),
+		'frameborder' => array()
+	);
+	$tags['object'] = array(
+		'height' => array(),
+		'width' => array()
+	);
 
-$allowedposttags['param'] = array(
-	'name' => array(),
-	'value' => array()
-);
+	$tags['param'] = array(
+		'name' => array(),
+		'value' => array()
+	);
 
-$allowedposttags['embed'] = array(
-	'src' => array(),
-	'type' => array(),
-	'allowfullscreen' => array(),
-	'allowscriptaccess' => array(),
-	'height' => array(),
-	'width' => array()
-);
-// Most of these attributes aren't actually valid for some of
-// the tags they're assigned to, but whatever:
-$allowedposttags['div'] =
-$allowedposttags['a'] =
-$allowedposttags['button'] = array(
-	'id' => array(),
-	'class' => array(),
-	'style' => array(),
-	'width' => array(),
-	'height' => array(),
+	$tags['embed'] = array(
+		'src' => array(),
+		'type' => array(),
+		'allowfullscreen' => array(),
+		'allowscriptaccess' => array(),
+		'height' => array(),
+		'width' => array()
+	);
+	// Most of these attributes aren't actually valid for some of
+	// the tags they're assigned to, but whatever:
+	$tags['div'] =
+	$tags['a'] =
+	$tags['button'] = array(
+		'id' => array(),
+		'class' => array(),
+		'style' => array(),
+		'width' => array(),
+		'height' => array(),
 
-	'align' => array(),
-	'aria-hidden' => array(),
-	'aria-labelledby' => array(),
-	'autofocus' => array(),
-	'dir' => array(),
-	'disabled' => array(),
-	'form' => array(),
-	'formaction' => array(),
-	'formenctype' => array(),
-	'formmethod' => array(),
-	'formonvalidate' => array(),
-	'formtarget' => array(),
-	'hidden' => array(),
-	'href' => array(),
-	'name' => array(),
-	'rel' => array(),
-	'rev' => array(),
-	'role' => array(),
-	'target' => array(),
-	'type' => array(),
-	'title' => array(),
-	'value' => array(),
+		'align' => array(),
+		'aria-hidden' => array(),
+		'aria-labelledby' => array(),
+		'autofocus' => array(),
+		'dir' => array(),
+		'disabled' => array(),
+		'form' => array(),
+		'formaction' => array(),
+		'formenctype' => array(),
+		'formmethod' => array(),
+		'formonvalidate' => array(),
+		'formtarget' => array(),
+		'hidden' => array(),
+		'href' => array(),
+		'name' => array(),
+		'rel' => array(),
+		'rev' => array(),
+		'role' => array(),
+		'target' => array(),
+		'type' => array(),
+		'title' => array(),
+		'value' => array(),
 
-	// Bootstrap JS stuff:
-	'data-dismiss' => array(),
-	'data-toggle' => array(),
-	'data-target' => array(),
-	'data-backdrop' => array(),
-	'data-spy' => array(),
-	'data-offset' => array(),
-	'data-animation' => array(),
-	'data-html' => array(),
-	'data-placement' => array(),
-	'data-selector' => array(),
-	'data-title' => array(),
-	'data-trigger' => array(),
-	'data-delay' => array(),
-	'data-content' => array(),
-	'data-offset' => array(),
-	'data-offset-top' => array(),
-	'data-loading-text' => array(),
-	'data-complete-text' => array(),
-	'autocomplete' => array(),
-	'data-parent' => array(),
-);
+		// Bootstrap JS stuff:
+		'data-dismiss' => array(),
+		'data-toggle' => array(),
+		'data-target' => array(),
+		'data-backdrop' => array(),
+		'data-spy' => array(),
+		'data-offset' => array(),
+		'data-animation' => array(),
+		'data-html' => array(),
+		'data-placement' => array(),
+		'data-selector' => array(),
+		'data-title' => array(),
+		'data-trigger' => array(),
+		'data-delay' => array(),
+		'data-content' => array(),
+		'data-offset' => array(),
+		'data-offset-top' => array(),
+		'data-loading-text' => array(),
+		'data-complete-text' => array(),
+		'autocomplete' => array(),
+		'data-parent' => array(),
+	);
+
+	return $tags;
+}
+
+add_filter( 'wp_kses_allowed_html', 'ucfwp_kses_allowed_html', 10, 2 );
 
 
 /**

--- a/includes/config.php
+++ b/includes/config.php
@@ -251,18 +251,18 @@ if ( function_exists( 'athena_sc_tinymce_init' ) ) {
  **/
 function ucfwp_kses_allowed_html( $tags, $context ) {
 	$global_attrs = array(
-		'aria-describedby' => array(),
-		'aria-details'     => array(),
-		'aria-label'       => array(),
-		'aria-labelledby'  => array(),
-		'aria-hidden'      => array(),
-		'class'            => array(),
-		'data-*'           => array(),
-		'hidden'           => array( 'valueless' => 'y' ),
-		'id'               => array(),
-		'role'             => array(),
-		'style'            => array(),
-		'title'            => array(),
+		'aria-describedby' => true,
+		'aria-details'     => true,
+		'aria-label'       => true,
+		'aria-labelledby'  => true,
+		'aria-hidden'      => true,
+		'class'            => true,
+		'data-*'           => true,
+		'hidden'           => array( 'valueless', 'y' ),
+		'id'               => true,
+		'role'             => true,
+		'style'            => true,
+		'title'            => true,
 	);
 
 	//
@@ -272,24 +272,24 @@ function ucfwp_kses_allowed_html( $tags, $context ) {
 	$tags['input'] = array_merge(
 		$global_attrs,
 		array(
-			'name'  => array(),
-			'type'  => array(),
-			'value' => array()
+			'name'  => true,
+			'type'  => true,
+			'value' => true
 		)
 	);
 
 	$tags['select'] = array_merge(
 		$global_attrs,
 		array(
-			'name' => array()
+			'name' => true
 		)
 	);
 
 	$tags['option'] = array_merge(
 		$global_attrs,
 		array(
-			'name'  => array(),
-			'value' => array()
+			'name'  => true,
+			'value' => true
 		)
 	);
 
@@ -300,42 +300,42 @@ function ucfwp_kses_allowed_html( $tags, $context ) {
 	$tags['iframe'] = array_merge(
 		$global_attrs,
 		array(
-			'allowfullscreen' => array(),
-			'frameborder'     => array(),
-			'height'          => array(),
-			'name'            => array(),
-			'src'             => array(),
-			'type'            => array(),
-			'value'           => array(),
-			'width'           => array()
+			'allowfullscreen' => true,
+			'frameborder'     => true,
+			'height'          => true,
+			'name'            => true,
+			'src'             => true,
+			'type'            => true,
+			'value'           => true,
+			'width'           => true
 		)
 	);
 
 	$tags['object'] = array_merge(
 		$global_attrs,
 		array(
-			'height' => array(),
-			'width'  => array()
+			'height' => true,
+			'width'  => true
 		)
 	);
 
 	$tags['param'] = array_merge(
 		$global_attrs,
 		array(
-			'name'  => array(),
-			'value' => array()
+			'name'  => true,
+			'value' => true
 		)
 	);
 
 	$tags['embed'] = array_merge(
 		$global_attrs,
 		array(
-			'allowfullscreen'   => array(),
-			'allowscriptaccess' => array(),
-			'height'            => array(),
-			'src'               => array(),
-			'type'              => array(),
-			'width'             => array()
+			'allowfullscreen'   => true,
+			'allowscriptaccess' => true,
+			'height'            => true,
+			'src'               => true,
+			'type'              => true,
+			'width'             => true
 		)
 	);
 
@@ -344,11 +344,11 @@ function ucfwp_kses_allowed_html( $tags, $context ) {
 	$tags['source'] = array_merge(
 		$global_attrs,
 		array(
-			'media'  => array(),
-			'sizes'  => array(),
-			'src'    => array(),
-			'srcset' => array(),
-			'type'   => array()
+			'media'  => true,
+			'sizes'  => true,
+			'src'    => true,
+			'srcset' => true,
+			'type'   => true
 		)
 	);
 
@@ -360,27 +360,27 @@ function ucfwp_kses_allowed_html( $tags, $context ) {
 	// they're assigned to, but that's intentional for
 	// backward compatibility:
 	$div_a_btn_attrs = array(
-		'width'  => array(),
-		'height' => array(),
+		'width'  => true,
+		'height' => true,
 
-		'align'          => array(),
-		'autocomplete'   => array(),
-		'autofocus'      => array(),
-		'dir'            => array(),
-		'disabled'       => array(),
-		'form'           => array(),
-		'formaction'     => array(),
-		'formenctype'    => array(),
-		'formmethod'     => array(),
-		'formonvalidate' => array(),
-		'formtarget'     => array(),
-		'href'           => array(),
-		'name'           => array(),
-		'rel'            => array(),
-		'rev'            => array(),
-		'target'         => array(),
-		'type'           => array(),
-		'value'          => array(),
+		'align'          => true,
+		'autocomplete'   => true,
+		'autofocus'      => true,
+		'dir'            => true,
+		'disabled'       => true,
+		'form'           => true,
+		'formaction'     => true,
+		'formenctype'    => true,
+		'formmethod'     => true,
+		'formonvalidate' => true,
+		'formtarget'     => true,
+		'href'           => true,
+		'name'           => true,
+		'rel'            => true,
+		'rev'            => true,
+		'target'         => true,
+		'type'           => true,
+		'value'          => true,
 	);
 
 	$tags['div'] = array_merge(
@@ -404,7 +404,7 @@ function ucfwp_kses_allowed_html( $tags, $context ) {
 	return $tags;
 }
 
-add_filter( 'wp_kses_allowed_html', 'ucfwp_kses_allowed_html', 999, 2 );
+add_filter( 'wp_kses_allowed_html', 'ucfwp_kses_allowed_html', 10, 2 );
 
 
 /**

--- a/includes/config.php
+++ b/includes/config.php
@@ -245,117 +245,166 @@ if ( function_exists( 'athena_sc_tinymce_init' ) ) {
 
 
 /**
- * Allow special tags in post bodies that would get stripped otherwise for most users.
+ * Allow special tags in post bodies that would get stripped
+ * otherwise for most users.
  * Modifies $allowedposttags defined in wp-includes/kses.php
  **/
 function ucfwp_kses_allowed_html( $tags, $context ) {
-	$tags['input'] = array(
-		'type' => array(),
-		'value' => array(),
-		'id' => array(),
-		'name' => array(),
-		'class' => array()
-	);
-	$tags['select'] = array(
-		'id' => array(),
-		'name' => array()
-	);
-	$tags['option'] = array(
-		'id' => array(),
-		'name' => array(),
-		'value' => array()
-	);
-	$tags['iframe'] = array(
-		'type' => array(),
-		'value' => array(),
-		'id' => array(),
-		'name' => array(),
-		'class' => array(),
-		'src' => array(),
-		'height' => array(),
-		'width' => array(),
-		'allowfullscreen' => array(),
-		'frameborder' => array()
-	);
-	$tags['object'] = array(
-		'height' => array(),
-		'width' => array()
+	$global_attrs = array(
+		'aria-describedby' => array(),
+		'aria-details'     => array(),
+		'aria-label'       => array(),
+		'aria-labelledby'  => array(),
+		'aria-hidden'      => array(),
+		'class'            => array(),
+		'data-*'           => array(),
+		'hidden'           => array( 'valueless' => 'y' ),
+		'id'               => array(),
+		'role'             => array(),
+		'style'            => array(),
+		'title'            => array(),
 	);
 
-	$tags['param'] = array(
-		'name' => array(),
-		'value' => array()
+	//
+	// Forms
+	//
+
+	$tags['input'] = array_merge(
+		$global_attrs,
+		array(
+			'name'  => array(),
+			'type'  => array(),
+			'value' => array()
+		)
 	);
 
-	$tags['embed'] = array(
-		'src' => array(),
-		'type' => array(),
-		'allowfullscreen' => array(),
-		'allowscriptaccess' => array(),
-		'height' => array(),
-		'width' => array()
+	$tags['select'] = array_merge(
+		$global_attrs,
+		array(
+			'name' => array()
+		)
 	);
-	// Most of these attributes aren't actually valid for some of
-	// the tags they're assigned to, but whatever:
-	$tags['div'] =
-	$tags['a'] =
-	$tags['button'] = array(
-		'id' => array(),
-		'class' => array(),
-		'style' => array(),
-		'width' => array(),
+
+	$tags['option'] = array_merge(
+		$global_attrs,
+		array(
+			'name'  => array(),
+			'value' => array()
+		)
+	);
+
+	//
+	// Embedded content
+	//
+
+	$tags['iframe'] = array_merge(
+		$global_attrs,
+		array(
+			'allowfullscreen' => array(),
+			'frameborder'     => array(),
+			'height'          => array(),
+			'name'            => array(),
+			'src'             => array(),
+			'type'            => array(),
+			'value'           => array(),
+			'width'           => array()
+		)
+	);
+
+	$tags['object'] = array_merge(
+		$global_attrs,
+		array(
+			'height' => array(),
+			'width'  => array()
+		)
+	);
+
+	$tags['param'] = array_merge(
+		$global_attrs,
+		array(
+			'name'  => array(),
+			'value' => array()
+		)
+	);
+
+	$tags['embed'] = array_merge(
+		$global_attrs,
+		array(
+			'allowfullscreen'   => array(),
+			'allowscriptaccess' => array(),
+			'height'            => array(),
+			'src'               => array(),
+			'type'              => array(),
+			'width'             => array()
+		)
+	);
+
+	$tags['picture'] = $global_attrs;
+
+	$tags['source'] = array_merge(
+		$global_attrs,
+		array(
+			'media'  => array(),
+			'sizes'  => array(),
+			'src'    => array(),
+			'srcset' => array(),
+			'type'   => array()
+		)
+	);
+
+	//
+	// Extensions of other, already-whitelisted elements
+	//
+
+	// Some of these attrs won't be valid on the elements
+	// they're assigned to, but that's intentional for
+	// backward compatibility:
+	$div_a_btn_attrs = array(
+		'width'  => array(),
 		'height' => array(),
 
-		'align' => array(),
-		'aria-hidden' => array(),
-		'aria-labelledby' => array(),
-		'autofocus' => array(),
-		'dir' => array(),
-		'disabled' => array(),
-		'form' => array(),
-		'formaction' => array(),
-		'formenctype' => array(),
-		'formmethod' => array(),
+		'align'          => array(),
+		'autocomplete'   => array(),
+		'autofocus'      => array(),
+		'dir'            => array(),
+		'disabled'       => array(),
+		'form'           => array(),
+		'formaction'     => array(),
+		'formenctype'    => array(),
+		'formmethod'     => array(),
 		'formonvalidate' => array(),
-		'formtarget' => array(),
-		'hidden' => array(),
-		'href' => array(),
-		'name' => array(),
-		'rel' => array(),
-		'rev' => array(),
-		'role' => array(),
-		'target' => array(),
-		'type' => array(),
-		'title' => array(),
-		'value' => array(),
+		'formtarget'     => array(),
+		'href'           => array(),
+		'name'           => array(),
+		'rel'            => array(),
+		'rev'            => array(),
+		'target'         => array(),
+		'type'           => array(),
+		'value'          => array(),
+	);
 
-		// Bootstrap JS stuff:
-		'data-dismiss' => array(),
-		'data-toggle' => array(),
-		'data-target' => array(),
-		'data-backdrop' => array(),
-		'data-spy' => array(),
-		'data-offset' => array(),
-		'data-animation' => array(),
-		'data-html' => array(),
-		'data-placement' => array(),
-		'data-selector' => array(),
-		'data-title' => array(),
-		'data-trigger' => array(),
-		'data-delay' => array(),
-		'data-content' => array(),
-		'data-offset' => array(),
-		'data-offset-top' => array(),
-		'data-loading-text' => array(),
-		'data-complete-text' => array(),
-		'autocomplete' => array(),
-		'data-parent' => array(),
+	$tags['div'] = array_merge(
+		$tags['div'] ?? array(),
+		$global_attrs,
+		$div_a_btn_attrs
+	);
+
+	$tags['a'] = array_merge(
+		$tags['a'] ?? array(),
+		$global_attrs,
+		$div_a_btn_attrs
+	);
+
+	$tags['button'] = array_merge(
+		$tags['button'] ?? array(),
+		$global_attrs,
+		$div_a_btn_attrs
 	);
 
 	return $tags;
 }
 
-add_filter( 'wp_kses_allowed_html', 'ucfwp_kses_allowed_html', 10, 2 );
+add_filter( 'wp_kses_allowed_html', 'ucfwp_kses_allowed_html', 999, 2 );
 
 
 /**


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Cleaned up KSES filtering overrides to utilize the designated `wp_kses_allowed_html` filter instead of overriding the global `$allowedposttags` variable manually.
- Updated existing tag overrides to utilize a global set of allowed attributes (`$global_attrs`) to reduce repetitive definitions.  In this set, we also allow wildcard data attributes (available since WP 5.-something), eliminating the need to define allowed data attributes individually
- Added `<picture>` and `<source>` as allowed tags.  This should avoid issues with most users having these tags stripped upon saving their posts, but [until WP core rolls out full support for `<picture>` and `srcset`](https://core.trac.wordpress.org/ticket/29807), there may still be issues with advanced `srcset` usage that we can't really fix.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows usage of `<picture>` and `<srcset>` in post content by users without the `unfiltered_html` capability.  Necessary for marking up things like media backgrounds with desktop and mobile images.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [x] I have updated the documentation accordingly.
