### PR TITLE
Improvements to how the page h1 is determined

### DIFF
--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -229,6 +229,29 @@ if ( !function_exists( 'ucfwp_get_header_h1_option' ) ) {
 
 
 /**
+ * Returns the HTML element that should surround the title text in
+ * the header (the page "h1", though this nomenclature is misleading.)
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
+ * @return string HTML element name
+ */
+if ( ! function_exists( 'ucfwp_get_header_h1_elem' ) ) {
+	function ucfwp_get_header_h1_elem( $obj ) {
+		$elem = 'h1';
+
+		$nav_title_elem = ucfwp_get_nav_title_elem();
+		if ( ucfwp_get_nav_title_elem() === 'h1' ) {
+			$elem = 'h2';
+		}
+
+		return apply_filters( 'ucfwp_get_header_h1_elem', $elem, $obj );
+	}
+}
+
+
+/**
  * Returns the type of header to use for the given object.
  * The value returned will represent an equivalent template part's name.
  *

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -232,7 +232,7 @@ if ( !function_exists( 'ucfwp_get_header_h1_option' ) ) {
  * Returns the HTML element that should surround the title text in
  * the header (the page "h1", though this nomenclature is misleading.)
  *
- * @since 1.0.0
+ * @since 0.6.3
  * @author Jo Dickson
  * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
  * @return string HTML element name
@@ -241,7 +241,6 @@ if ( ! function_exists( 'ucfwp_get_header_h1_elem' ) ) {
 	function ucfwp_get_header_h1_elem( $obj ) {
 		$elem = 'h1';
 
-		$nav_title_elem = ucfwp_get_nav_title_elem();
 		if ( ucfwp_get_nav_title_elem() === 'h1' ) {
 			$elem = 'h2';
 		}

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -241,11 +241,12 @@ if ( ! function_exists( 'ucfwp_get_header_h1_elem' ) ) {
 	function ucfwp_get_header_h1_elem( $obj ) {
 		$elem = 'h1';
 
-		if ( ucfwp_get_nav_title_elem() === 'h1' ) {
+		$nav_title_elem = ucfwp_get_nav_title_elem();
+		if ( $nav_title_elem === 'h1' ) {
 			$elem = 'h2';
 		}
 
-		return apply_filters( 'ucfwp_get_header_h1_elem', $elem, $obj );
+		return apply_filters( 'ucfwp_get_header_h1_elem', $elem, $nav_title_elem, $obj );
 	}
 }
 

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -54,35 +54,35 @@ if ( ! function_exists( 'ucfwp_nav_has_title' ) ) {
  *
  * @since 0.6.3
  * @author Jo Dickson
- * @return mixed HTML element name (string), or null if the nav template part doesn't incorporate the site title
+ * @return mixed HTML element name (string), or null if the nav template part doesn't incorporate the site title, or is disabled
  */
 if ( ! function_exists( 'ucfwp_get_nav_title_elem' ) ) {
 	function ucfwp_get_nav_title_elem() {
+		// If the active nav template part doesn't incorporate the
+		// site title at all, back out now:
 		if ( ! ucfwp_nav_has_title() ) return null;
 
+		// The title elem should render as a `span` by default in all
+		// cases, except for on the homepage/front page:
 		$title_elem = 'span';
 		$obj = ucfwp_get_queried_object();
 
-		// We only need to adjust the title elem on the homepage/front page:
-		if ( ! $obj ) {
-			$show_on_front = get_option( 'show_on_front' );
-			$homepage_id = get_option( 'page_on_front' );
-
-			if (
-				$show_on_front === 'posts'
-				|| ( $show_on_front === 'page' && ! $homepage_id )
-			) {
-				$title_elem = 'h1';
-			}
+		// If we're on the "home" view and $obj is null, assume that
+		// "Your homepage displays" is set to "Your latest posts",
+		// OR is set to "A static page", but the "Homepage" value
+		// is left blank:
+		if ( ! $obj && is_home() ) {
+			$title_elem = 'h1';
 		}
-		elseif ( $obj instanceof WP_Post && $obj->post_type === 'page' ) {
-			$show_on_front = get_option( 'show_on_front' );
-			$homepage_id = (int)get_option( 'page_on_front' );
-
-			if ( $show_on_front === 'page' ) {
-				if ( $obj->ID === $homepage_id ) {
-					$title_elem = 'h1';
-				}
+		// An actual, valid page is set as the homepage:
+		elseif ( $obj && is_front_page() ) {
+			// Account for when the front page opts to exclude
+			// the primary site navigation from the header:
+			if ( get_field( 'page_header_exclude_nav', $obj ) === true ) {
+				$title_elem = null;
+			}
+			else {
+				$title_elem = 'h1';
 			}
 		}
 

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -24,6 +24,74 @@ if ( !function_exists( 'ucfwp_get_nav_type' ) ) {
 
 
 /**
+ * Returns whether or not the active nav template includes the site title.
+ * Used when determining a page's heading element.
+ *
+ * Child themes should override the `ucfwp_nav_has_title` hook if they
+ * define a custom nav template part that does *not* include the site title.
+ *
+ * @since 0.6.3
+ * @author Jo Dickson
+ * @return boolean True if the nav template part includes the site's title, False if not
+ */
+if ( ! function_exists( 'ucfwp_nav_has_title' ) ) {
+	function ucfwp_nav_has_title() {
+		$has_title = true;
+		$nav_type = ucfwp_get_nav_type();
+
+		if ( $nav_type === 'mainsite' ) {
+			$has_title = false;
+		}
+
+		return apply_filters( 'ucfwp_nav_has_title', $has_title, $nav_type );
+	}
+}
+
+
+/**
+ * Returns what element should be used to wrap the site title
+ * within the active nav template part.
+ *
+ * @since 0.6.3
+ * @author Jo Dickson
+ * @return mixed HTML element name (string), or null if the nav template part doesn't incorporate the site title
+ */
+if ( ! function_exists( 'ucfwp_get_nav_title_elem' ) ) {
+	function ucfwp_get_nav_title_elem() {
+		if ( ! ucfwp_nav_has_title() ) return null;
+
+		$title_elem = 'span';
+		$obj = ucfwp_get_queried_object();
+
+		// We only need to adjust the title elem on the homepage/front page:
+		if ( ! $obj ) {
+			$show_on_front = get_option( 'show_on_front' );
+			$homepage_id = get_option( 'page_on_front' );
+
+			if (
+				$show_on_front === 'posts'
+				|| ( $show_on_front === 'page' && ! $homepage_id )
+			) {
+				$title_elem = 'h1';
+			}
+		}
+		elseif ( $obj instanceof WP_Post && $obj->post_type === 'page' ) {
+			$show_on_front = get_option( 'show_on_front' );
+			$homepage_id = (int)get_option( 'page_on_front' );
+
+			if ( $show_on_front === 'page' ) {
+				if ( $obj->ID === $homepage_id ) {
+					$title_elem = 'h1';
+				}
+			}
+		}
+
+		return apply_filters( 'ucfwp_get_nav_title_elem', $title_elem, $obj );
+	}
+}
+
+
+/**
  * Returns HTML markup for the primary site navigation.
  *
  * @author Jo Dickson

--- a/template-parts/header_content-title_subtitle.php
+++ b/template-parts/header_content-title_subtitle.php
@@ -3,7 +3,7 @@ $obj           = ucfwp_get_queried_object();
 $title         = ucfwp_get_header_title( $obj );
 $subtitle      = ucfwp_get_header_subtitle( $obj );
 $h1            = ucfwp_get_header_h1_option( $obj );
-$h1_elem       = ( is_home() || is_front_page() ) ? 'h2' : 'h1'; // name is misleading but we need to override this elem on the homepage
+$h1_elem       = ucfwp_get_header_h1_elem( $obj );
 $title_elem    = ( $h1 === 'title' ) ? $h1_elem : 'span';
 $subtitle_elem = ( $h1 === 'subtitle' ) ? $h1_elem : 'span';
 ?>

--- a/template-parts/header_content.php
+++ b/template-parts/header_content.php
@@ -3,7 +3,7 @@ $obj              = ucfwp_get_queried_object();
 $title            = ucfwp_get_header_title( $obj );
 $subtitle         = ucfwp_get_header_subtitle( $obj );
 $h1               = ucfwp_get_header_h1_option( $obj );
-$h1_elem          = ( is_home() || is_front_page() ) ? 'h2' : 'h1'; // name is misleading but we need to override this elem on the homepage
+$h1_elem          = ucfwp_get_header_h1_elem( $obj );
 $title_elem       = ( $h1 === 'title' ) ? $h1_elem : 'span';
 $subtitle_elem    = ( $h1 === 'subtitle' ) ? $h1_elem : 'p';
 $title_classes    = 'h1 d-block mt-3 mt-sm-4 mt-md-5 mb-2 mb-md-3';

--- a/template-parts/nav.php
+++ b/template-parts/nav.php
@@ -1,6 +1,6 @@
 <?php
 $image      = (bool) get_query_var( 'ucfwp_image_behind_nav', false );
-$title_elem = ( is_home() || is_front_page() ) ? 'h1' : 'span';
+$title_elem = ucfwp_get_nav_title_elem();
 
 $menu_container_class = 'collapse navbar-collapse';
 if ( ! $image ) {


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added functions for determining what type of element to wrap the site title within the primary navigation in, as well as the title text within the page header, instead of relying solely on `is_home() || is_front_page()`.

Another new function, `ucfwp_nav_has_title()`, has been added to help determine whether the primary site navigation includes the site title at all (and accounts for the fallback main site navigation, which does not include the site title).  Child themes that implement a primary site navigation option that _does not_ include the site title within it should hook into the new `ucfwp_nav_has_title` filter hook and override its returned value appropriately.

All of this logic exists to ensure the site title within the primary site nav is made the `<h1>` on whatever the homepage is, instead of the page title (assuming the site nav is visible and incorporates the site title).  On all other views/subpages, the site title should render as a `<span>` (if present), and the page title should be made the `<h1>`.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are some edge cases that weren't being accounted for previously, such as if the site's homepage had the primary site navigation disabled, and the primary site nav included the site title (which otherwise becomes the h1 on the homepage).

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
