### PR TITLE
Fallback font preload

### DIFF
--- a/includes/meta.php
+++ b/includes/meta.php
@@ -87,11 +87,23 @@ if ( $gw_verify ):
 <?php endif; ?>
 
 <?php
-// Preload Cloud.Typography
+// Preload Cloud.Typography or fallback fonts
 if ( $fontkey = get_theme_mod( 'cloud_typography_key' ) ) :
 ?>
 <link rel="preload" href="<?php echo $fontkey; ?>" as="style">
-<?php endif; ?>
+<?php
+else:
+	$fallback_fonts = (array) apply_filters( 'ucfwp_preload_athena_fallback_fonts', array(
+		UCFWP_THEME_FONT_URL . '/ucf-sans-serif-alt/ucfsansserifalt-medium-webfont.woff2',
+		UCFWP_THEME_FONT_URL . '/ucf-sans-serif-alt/ucfsansserifalt-bold-webfont.woff2',
+	) );
+	foreach ( $fallback_fonts as $fb_font ) :
+?>
+<link rel="preload" href="<?php echo $fb_font; ?>" as="font" type="font/woff2" crossorigin>
+<?php
+	endforeach;
+endif;
+?>
 
 <?php
 // Preload Font Awesome


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds loading of Athena's fallback sans-serif webfonts (book and bold) when Cloud.Typography is not in use.  (It looks weird, but the "medium" weight is used as the standard 400/book weight; see https://github.com/UCF/Athena-Framework/blob/master/src/scss/_fonts.scss#L8-L16)

While we could preload more fonts, the sans-serif book/bold weights are going to be the most frequently used, and would benefit the most from preloading.  Child themes can add/remove preloaded Athena fonts as needed with the `ucfwp_preload_athena_fallback_fonts` filter hook.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To satisfy Pagespeed Insights/Lighthouse issues about preloading critical assets.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [x] I have updated the documentation accordingly.
