### PR TITLE
set a fallback for alt image in header background.

### DIFF
--- a/includes/media-backgrounds.php
+++ b/includes/media-backgrounds.php
@@ -66,11 +66,7 @@ function ucfwp_get_media_background_picture_srcs( $attachment_xs_id, $attachment
  * @return string
  **/
 if ( ! function_exists( 'ucfwp_get_media_background_picture' ) ) {
-	function ucfwp_get_media_background_picture( $srcs, $image_alt ) {
-		// If no image alt text is provided, use a default value
-		if ( !$image_alt ) {
-			$image_alt = 'header background image';
-		}
+	function ucfwp_get_media_background_picture( $srcs, $image_alt = 'header background image' ) {
 		// NOTE: if a child theme overrides the `ucfwp_media_background_picture_object_position`
 		// hook, that theme must also provide a style override to
 		// `.media-background` to set the object-position property

--- a/includes/media-backgrounds.php
+++ b/includes/media-backgrounds.php
@@ -66,7 +66,11 @@ function ucfwp_get_media_background_picture_srcs( $attachment_xs_id, $attachment
  * @return string
  **/
 if ( ! function_exists( 'ucfwp_get_media_background_picture' ) ) {
-	function ucfwp_get_media_background_picture( $srcs ) {
+	function ucfwp_get_media_background_picture( $srcs, $image_alt ) {
+		// If no image alt text is provided, use a default value
+		if ( !$image_alt ) {
+			$image_alt = 'header background image';
+		}
 		// NOTE: if a child theme overrides the `ucfwp_media_background_picture_object_position`
 		// hook, that theme must also provide a style override to
 		// `.media-background` to set the object-position property
@@ -98,7 +102,7 @@ if ( ! function_exists( 'ucfwp_get_media_background_picture' ) ) {
 			<source srcset="<?php echo $srcs['xs']; ?>" media="(max-width: 575px)">
 			<?php endif; ?>
 
-			<img class="media-background object-fit-cover" src="<?php echo $srcs['fallback']; ?>" alt="" <?php echo $object_position_attr; ?>>
+			<img class="media-background object-fit-cover" src="<?php echo $srcs['fallback']; ?>" alt="<?php echo $image_alt ?>" <?php echo $object_position_attr; ?>>
 		</picture>
 	<?php
 		endif;


### PR DESCRIPTION
**Description**
We are adding a new argument to the ucfwp_get_media_background_picture() function called $image_alt. From now on, this parameter will be passed to the function. Since we are currently passing the alt text only from the online-child-theme, other themes will not provide this parameter. To handle that, we’ve added a fallback: $image_alt = 'header background image'.

This means that any website or child theme using the UCF-WordPress-theme will now register a default alt text unless we explicitly update each child theme to pass the alt text from the header images.

**Motivation and Context**
To improve accessibility, we need to register alt to header image.

**How Has This Been Tested?**
Yes, on local.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
