### PR TITLE
PHP Depreciation Notice Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ build/*
 *.xcworkspace
 xcuserdata
 
+# jetbrains project files
+.idea
+
 # svn & cvs
 .svn
 CVS

--- a/404.php
+++ b/404.php
@@ -5,7 +5,7 @@
 <article id="page-not-found">
 	<div class="container mt-4 mt-sm-5 mb-5 pb-sm-4">
 		<?php
-        $page = ucfwp_get_post_by_title( '404', 'page');
+        $page = ucfwp_get_page_by_title( '404');
 		$content = '';
         if ( $page ) {
             $content = trim( apply_filters( 'the_content', $page->post_content ) );

--- a/404.php
+++ b/404.php
@@ -5,11 +5,11 @@
 <article id="page-not-found">
 	<div class="container mt-4 mt-sm-5 mb-5 pb-sm-4">
 		<?php
-		$page = get_page_by_title( '404' );
+        $page = ucfwp_get_post_by_title( '404', 'page');
 		$content = '';
-		if ( $page && $page->post_status === 'publish' ) {
-			$content = trim( apply_filters( 'the_content', $page->post_content ) );
-		}
+        if ( $page ) {
+            $content = trim( apply_filters( 'the_content', $page->post_content ) );
+        }
 		?>
 		<?php if ( $content ): ?>
 			<?php echo $content; ?>

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -201,7 +201,7 @@ function ucfwp_get_header_subtitle( $obj ) {
 		return wptexturize( $subtitle );
 	}
 
-    if($subtitle_field = get_field( 'page_header_subtitle', $obj )) {
+    if ( $subtitle_field = get_field( 'page_header_subtitle', $obj ) ) {
         // get_field() can return null if a field hasn't been saved previously, throwing notices in do_shortcode()
         $subtitle = do_shortcode( $subtitle_field );
     }

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -201,9 +201,9 @@ function ucfwp_get_header_subtitle( $obj ) {
 		return wptexturize( $subtitle );
 	}
 
-    if(get_field( 'page_header_subtitle', $obj )) {
-        // get_field() can return null if a field hasn't been saved previously, throwing warnings in do_shortcode()
-        $subtitle = do_shortcode( get_field( 'page_header_subtitle', $obj ) );
+    if($subtitle_field = get_field( 'page_header_subtitle', $obj )) {
+        // get_field() can return null if a field hasn't been saved previously, throwing notices in do_shortcode()
+        $subtitle = do_shortcode( $subtitle_field );
     }
 
 	$subtitle = (string) apply_filters( 'ucfwp_get_header_subtitle_after', $subtitle, $obj );

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -69,7 +69,7 @@ function ucfwp_get_header_videos( $obj ) {
 	if ( $obj_header_video_mp4 = get_field( 'page_header_mp4', $obj ) ) {
 		$retval['mp4'] = $obj_header_video_mp4;
 	}
-    
+
 	if ( $obj_header_video_webm = get_field( 'page_header_webm', $obj ) ) {
 		$retval['webm'] = $obj_header_video_webm;
 	}
@@ -201,7 +201,10 @@ function ucfwp_get_header_subtitle( $obj ) {
 		return wptexturize( $subtitle );
 	}
 
-	$subtitle = do_shortcode( get_field( 'page_header_subtitle', $obj ) );
+    if(get_field( 'page_header_subtitle', $obj )) {
+        // get_field() can return null if a field hasn't been saved previously, throwing warnings in do_shortcode()
+        $subtitle = do_shortcode( get_field( 'page_header_subtitle', $obj ) );
+    }
 
 	$subtitle = (string) apply_filters( 'ucfwp_get_header_subtitle_after', $subtitle, $obj );
 

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -10,7 +10,8 @@
  * @author Jo Dickson
  * @since 0.0.0
  * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
- * @return array A set of Attachment IDs, one sized for use on -sm+ screens, and another for -xs
+ * @return array|false A set of Attachment IDs, one sized for use on -sm+ screens, and another for -xs, or false if no
+ *  image is set.
  **/
 function ucfwp_get_header_images( $obj ) {
 	$retval = array(
@@ -27,6 +28,7 @@ function ucfwp_get_header_images( $obj ) {
 	if ( $obj_header_image = get_field( 'page_header_image', $obj ) ) {
 		$retval['header_image'] = $obj_header_image;
 	}
+
 	if ( $obj_header_image_xs = get_field( 'page_header_image_xs', $obj ) ) {
 		$retval['header_image_xs'] = $obj_header_image_xs;
 	}
@@ -36,6 +38,7 @@ function ucfwp_get_header_images( $obj ) {
 	if ( isset( $retval['header_image'] ) && $retval['header_image'] ) {
 		return $retval;
 	}
+
 	return false;
 }
 
@@ -47,7 +50,8 @@ function ucfwp_get_header_images( $obj ) {
  * @author Jo Dickson
  * @since 0.0.0
  * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
- * @return array A set of Attachment urls corresponding to available video filetypes
+ * @return array|false A set of Attachment urls corresponding to available video filetypes, returns false if no mp4
+ *  format video is provided.
  **/
 function ucfwp_get_header_videos( $obj ) {
 	$retval = array(
@@ -65,6 +69,7 @@ function ucfwp_get_header_videos( $obj ) {
 	if ( $obj_header_video_mp4 = get_field( 'page_header_mp4', $obj ) ) {
 		$retval['mp4'] = $obj_header_video_mp4;
 	}
+    
 	if ( $obj_header_video_webm = get_field( 'page_header_webm', $obj ) ) {
 		$retval['webm'] = $obj_header_video_webm;
 	}
@@ -76,6 +81,7 @@ function ucfwp_get_header_videos( $obj ) {
 	if ( isset( $retval['mp4'] ) && $retval['mp4'] ) {
 		return $retval;
 	}
+
 	return false;
 }
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -261,7 +261,7 @@ if ( ! function_exists( 'ucfwp_get_page_by_title' ) ) {
      * @since 0.11.2
      * @see https://make.wordpress.org/core/2023/03/06/get_page_by_title-deprecated/
      */
-    function ucfwp_get_page_by_title($title, $output = OBJECT, $post_type = 'page', $status = 'publish' ) {
+    function ucfwp_get_page_by_title( $title, $output = OBJECT, $post_type = 'page', $status = 'publish' ) {
         $posts = get_posts(
             array(
                 'post_type'              => $post_type,
@@ -282,7 +282,7 @@ if ( ! function_exists( 'ucfwp_get_page_by_title' ) ) {
             $post = null;
         }
 
-        if($post) {
+        if( $post ) {
             // Convert to array formats as needed. For backwards compatibility with get_page_by_title()
             if ( ARRAY_A === $output ) {
                 return $post->to_array();

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -245,29 +245,29 @@ if ( ! function_exists( 'ucfwp_get_template_part_slug' ) ) {
 
 if ( ! function_exists( 'ucfwp_get_page_by_title' ) ) {
     /**
-     * Returns a post object found as the results of a query by title. This is compatible with the WordPress function
-     * get_page_by_title(), which was depreciated in version 6.2, but will check both posts and pages, and only
-     * return published posts to avoid unintended access to private or draft posts.
+     * Returns a page found as the results of a query by title. This is compatible with the WordPress function
+     * get_page_by_title(), which was depreciated in version 6.2, but by default will only return published posts to avoid
+     * unintended access to private or draft posts.
      *
-     * To fully replicate the exact behavior of get_page_by_title() use ucfwp_get_post_by_title($title, "page", "all")
+     * To fully replicate the original behavior of get_page_by_title() use ucfwp_get_page_by_title($title, $output, "page", "all")
      *
      * @author Jake Finley & Peter Wilson
-     * @param string $title
-     * @param string[] $post_type
-     * @param string $status
-     * @return WP_Post|null The post with a matching title, or null if none is found.
+     * @param string $title Page title.
+     * @param string $output The required return type. One of OBJECT, ARRAY_A, or ARRAY_N, which correspond to a
+     *  WP_Post object, an associative array, or a numeric array, respectively.
+     * @param string|string[] $post_type Post type or array of post types.
+     * @param string|string[] $status Post status or array of post statuses that should be queried.
+     * @return WP_Post|array|null The post with a matching title, or null if none is found.
      * @since 0.11.2
      * @see https://make.wordpress.org/core/2023/03/06/get_page_by_title-deprecated/
      */
-    function ucfwp_get_post_by_title($title, $post_type = ['post', 'page'], $status = 'publish' ) {
-        $query = new WP_Query(
+    function ucfwp_get_page_by_title($title, $output = OBJECT, $post_type = 'page', $status = 'publish' ) {
+        $posts = get_posts(
             array(
                 'post_type'              => $post_type,
                 'title'                  => $title,
                 'post_status'            => $status,
-                'posts_per_page'         => 1,
-                'no_found_rows'          => true,
-                'ignore_sticky_posts'    => true,
+                'numberposts'            => 1,
                 'update_post_term_cache' => false,
                 'update_post_meta_cache' => false,
                 'orderby'                => 'date ID',
@@ -275,13 +275,24 @@ if ( ! function_exists( 'ucfwp_get_page_by_title' ) ) {
             )
         );
 
-        if ( ! empty( $query->post ) ) {
-            $page_got_by_title = $query->post;
+        // Get individual post object if it exists
+        if ( ! empty( $posts ) ) {
+            $post = $posts[0];
         } else {
-            $page_got_by_title = null;
+            $post = null;
         }
 
-        return $page_got_by_title;
+        if($post) {
+            // Convert to array formats as needed. For backwards compatibility with get_page_by_title()
+            if ( ARRAY_A === $output ) {
+                return $post->to_array();
+            } elseif ( ARRAY_N === $output ) {
+                return array_values( $post->to_array() );
+            }
+        }
+
+        // Returns WP_Post or null
+        return $post;
     }
 }
 
@@ -311,7 +322,7 @@ function ucfwp_get_queried_object() {
 	$obj = get_queried_object();
 
 	if ( !$obj && is_404() ) {
-        $page = ucfwp_get_post_by_title( '404',  'page' );
+        $page = ucfwp_get_page_by_title( '404' );
         if ( $page ) {
             $obj = $page;
         }


### PR DESCRIPTION
**Description**
Hi, I'm a member of the dev team working on the new UCF Foundation site (soon to be UCF Advancement).

This pull request fixes two minor issues: A PHP depreciation notice that can occur in the header code when get_field() is ran on a field that has not yet been initialized, and a WordPress depreciation notice introduced in version 6.2. 

The former is fixed simply by checking the value before running it through do_shortcode(), while the latter is fixed by implementing the [recommended solution](https://make.wordpress.org/core/2023/03/06/get_page_by_title-deprecated/) by the WordPress core team, with a slight modification to fully replicate the function signature of the depreciated function and allow it to serve as a drop-in replacement with one sensible/security tweak (it defaults to only querying published posts). Two checks for a published 404 error page have been converted to a simple check for the post object existing, as the check for published post status is no longer required.

Additionally, I noticed that some of the PHPDoc comments for some of the header functions was inaccurate, and I have updated these to match what the code is actually doing. No functionality change, just minor corrections to the documentation.

**Motivation and Context**
This fixes the following PHP & WordPress depreciation notices, reducing error log clutter and future-proofing the theme. It also implements a new function that child themes can opt-in to using if they have need of a get_page_by_title() replacement.

`PHP Deprecated:  Function get_page_by_title is <strong>deprecated</strong> since version 6.2.0! Use WP_Query instead. in \wp-includes\functions.php on line 6131`

`PHP Deprecated:  str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in \wp-includes\shortcodes.php on line 246`

**How Has This Been Tested?**
This is currently being used on the new UCF Advancement site, however as this site uses Elementor and runs the UCF theme as a parent theme, not all functions from the parent theme are being used. I did check the 404 functionality manually, and it works as expected, including unpublishing the page and having it no longer serve as the 404 page template.

**Types of changes**
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [ x ] My code follows the code style of this project.
- [ x ] My change requires an update to the documentation.
- [ x ] I have updated the documentation accordingly.
