### PR TITLE
Add Split Dropdown Navigation Support Using Athena Framework Component

### DIFF
--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -397,3 +397,63 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 	}
 
 }
+
+/*
+ * Add a "Split dropdown" checkbox to menu items.
+ * @author Jhon Tabio
+ * @since unknown
+ *
+ * @param int    $menu_item_id The menu item ID.
+ * @param object $item         The current menu item.
+ * @param int    $depth        Depth of menu item. Used for padding.
+ * @param array  $args         An array of {@see wp_nav_menu()} arguments.
+ * @return void
+ */
+add_action('wp_nav_menu_item_custom_fields', function( $menu_item_id, $item, $depth, $args) {
+	if ((int) $depth !== 0) { return; }
+
+	$value = get_post_meta( $menu_item_id, '_menu_item_split_dropdown', true );
+	?>
+	<p class="field-split-dropdown description description-wide">
+		<label for="edit-menu-item-split-dropdown-<?php echo esc_attr( $menu_item_id ); ?>">
+			<input type="checkbox"
+				id="edit-menu-item-split-dropdown-<?php echo esc_attr( $menu_item_id ); ?>"
+				name="menu-item-split-dropdown[<?php echo esc_attr( $menu_item_id ); ?>]"
+				value="1" <?php checked( $value, '1' ); ?> />
+			Split dropdown
+		</label>
+	</p>
+	<?php
+}, 10, 4 );
+
+/*
+ * Save the checkbox value.
+ * @author Jhon Tabio
+ * @since unknown
+ *
+ * @param string $menu_id       Menu item ID.
+ * @param string $menu_id_db_id Menu item post ID (nav_menu_item ID).
+ * @param array  $args          An array of {@see wp_nav_menu()} arguments.
+ * @return void
+ */
+add_action('wp_update_nav_menu_item', function( $menu_id, $menu_item_db_id, $args) {
+   $is_set = isset($_POST['menu-item-split-dropdown'][ $menu_item_db_id ]) ? '1' : '';
+   if ($is_set !== '') {
+       update_post_meta($menu_item_db_id, '_menu_item_split_dropdown', '1');
+   } else {
+       delete_post_meta($menu_item_db_id, '_menu_item_split_dropdown');
+   }
+}, 10, 3 );
+
+/*
+ * Load the value onto the menu item object for the walker.
+ * @author Jhon Tabio
+ * @since unknown
+ *
+ * @param  object $item Menu item object.
+ * @return object       Modified menu item object.
+ */
+add_filter( 'wp_setup_nav_menu_item', function( $item ) {
+   $item->split_dropdown = ( get_post_meta( $item->ID, '_menu_item_split_dropdown', true ) === '1' );
+   return $item;
+});

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -444,12 +444,14 @@ add_action( 'wp_nav_menu_item_custom_fields', function( $menu_item_id, $item, $d
 	if ( (int) $depth !== 0 ) { return; }
 
 	$value = get_post_meta( $menu_item_id, '_menu_item_split_dropdown', true );
+	$field_id  = 'edit-menu-item-split-dropdown-' . esc_attr( $menu_item_id );
+	$field_name = 'menu-item-split-dropdown[' . esc_attr( $menu_item_id ) . ']';
 	?>
 	<p class="field-split-dropdown description">
-		<label for="edit-menu-item-split-dropdown-<?php echo esc_attr( $menu_item_id ); ?>">
+		<label for="<?php echo esc_attr( $field_id ); ?>">
 			<input type="checkbox"
-				id="edit-menu-item-split-dropdown-<?php echo esc_attr( $menu_item_id ); ?>"
-				name="menu-item-split-dropdown[<?php echo esc_attr( $menu_item_id ); ?>]"
+				id="<?php echo esc_attr( $field_id ); ?>"
+				name="<?php echo esc_attr( $field_name ); ?>]"
 				value="1" <?php checked( $value, '1' ); ?> />
 			Split dropdown
 		</label>
@@ -468,12 +470,13 @@ add_action( 'wp_nav_menu_item_custom_fields', function( $menu_item_id, $item, $d
  * @return void
  */
 add_action( 'wp_update_nav_menu_item', function( $menu_id, $menu_item_db_id, $args ) {
-   $is_set = isset( $_POST['menu-item-split-dropdown'][ $menu_item_db_id ] ) ? '1' : '';
-   if ( $is_set !== '' ) {
-       update_post_meta( $menu_item_db_id, '_menu_item_split_dropdown', '1' );
-   } else {
-       delete_post_meta( $menu_item_db_id, '_menu_item_split_dropdown' );
-   }
+	$meta_key = '_menu_item_split_dropdown';
+	$is_set = isset( $_POST['menu-item-split-dropdown'][ $menu_item_db_id ] ) ? '1' : '';
+	if ( $is_set !== '' ) {
+	    update_post_meta( $menu_item_db_id, $meta_key, '1' );
+	} else {
+	    delete_post_meta( $menu_item_db_id, $meta_key );
+	}
 }, 10, 3 );
 
 /*
@@ -500,42 +503,42 @@ add_filter( 'wp_setup_nav_menu_item', function( $item ) {
  * @return void
  */
 add_action( 'admin_enqueue_scripts', function( $hook ) {
-    if ( $hook !== 'nav-menus.php' ){ return; }
+	if ( $hook !== 'nav-menus.php' ){ return; }
 
-    $css = <<<CSS
-    .menu-item-settings .field-link-target,
-    .menu-item-settings .field-split-dropdown {
-        display: inline-block;
-        vertical-align: middle;
-        margin-right: 12px;
-        margin-bottom: 0;
-        width: auto;
-    }
-    CSS;
+	$css = <<<CSS
+	.menu-item-settings .field-link-target,
+	.menu-item-settings .field-split-dropdown {
+	    display: inline-block;
+	    margin-bottom: 0;
+	    margin-right: 12px;
+	    vertical-align: middle;
+	    width: auto;
+	}
+	CSS;
 
-    wp_add_inline_style( 'common', $css );
+	wp_add_inline_style( 'common', $css );
 
-    $js = <<<JS
-    jQuery(function($){
-        function repositionSplitDropdown(context){
-            $(context).find('.menu-item-settings').each(function(){
-                var \$settings = $(this);
-                var \$split  = \$settings.find('.field-split-dropdown');
-                var \$target = \$settings.find('.field-link-target'); // "Open link in a new tab"
+	$js = <<<JS
+	jQuery(function ($) {
+	  function repositionSplitDropdown(context) {
+	    $(context).find('.menu-item-settings').each(function () {
+	      var \$settings = $(this);
+	      var \$split = \$settings.find('.field-split-dropdown');
+	      var \$target = \$settings.find('.field-link-target'); // "Open link in a new tab"
 
-                if (\$split.length && \$target.length) {
-                    \$split.insertAfter(\$target);
-                }
-            });
-        }
+	      if (\$split.length && \$target.length) {
+	        \$split.insertAfter(\$target);
+	      }
+	    });
+	  }
 
-        repositionSplitDropdown(document);
+	  repositionSplitDropdown(document);
 
-        $(document).on('menu-item-added menu-item-settings-expanded', function(e){
-            repositionSplitDropdown(e.target);
-        });
-    });
-    JS;
+	  $(document).on('menu-item-added menu-item-settings-expanded', function (e) {
+	    repositionSplitDropdown(e.target);
+	  });
+	});
+	JS;
 
-    wp_add_inline_script( 'nav-menu', $js );
+	wp_add_inline_script( 'nav-menu', $js );
 });

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -356,8 +356,6 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 			//
 			if($depth === 0 && in_array('menu-item-has-children', $classes) && get_post_meta($item->ID, '_menu_item_split_dropdown', true) === '1')
 			{
-				$item_output .= '<div class="btn-group">';
-
 				$item_output .= '<a' . $attributes. '>';
 				$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
 				$item_output .= '</a>';
@@ -378,9 +376,6 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 				}
 
 				$item_output .= '<a' . $toggle_attr_str . '></a>';
-				
-				$item_output .= '</div>';
-	
 			}
 			else
 			{

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -442,11 +442,11 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
  * @return void
  */
 add_action('wp_nav_menu_item_custom_fields', function( $menu_item_id, $item, $depth, $args) {
-	if ((int) $depth !== 0) { return; }
+	if ((int) $depth !== 0){ return; }
 
 	$value = get_post_meta( $menu_item_id, '_menu_item_split_dropdown', true );
 	?>
-	<p class="field-split-dropdown description description-wide">
+	<p class="field-split-dropdown description">
 		<label for="edit-menu-item-split-dropdown-<?php echo esc_attr( $menu_item_id ); ?>">
 			<input type="checkbox"
 				id="edit-menu-item-split-dropdown-<?php echo esc_attr( $menu_item_id ); ?>"
@@ -488,4 +488,45 @@ add_action('wp_update_nav_menu_item', function( $menu_id, $menu_item_db_id, $arg
 add_filter( 'wp_setup_nav_menu_item', function( $item ) {
    $item->split_dropdown = ( get_post_meta( $item->ID, '_menu_item_split_dropdown', true ) === '1' );
    return $item;
+});
+
+add_action('admin_enqueue_scripts', function( $hook ) {
+    if ($hook !== 'nav-menus.php'){ return; }
+
+    $css = <<<CSS
+    .menu-item-settings .field-link-target,
+    .menu-item-settings .field-split-dropdown {
+        display: inline-block;
+        vertical-align: middle;
+        margin-right: 12px;
+        margin-bottom: 0;
+        width: auto;
+    }
+    CSS;
+
+    wp_add_inline_style('common', $css);
+
+    $js = <<<JS
+    jQuery(function($){
+        function repositionSplitDropdown(context){
+            $(context).find('.menu-item-settings').each(function(){
+                var \$settings = $(this);
+                var \$split  = \$settings.find('.field-split-dropdown');
+                var \$target = \$settings.find('.field-link-target'); // "Open link in a new tab"
+
+                if (\$split.length && \$target.length) {
+                    \$split.insertAfter(\$target);
+                }
+            });
+        }
+
+        repositionSplitDropdown(document);
+
+        $(document).on('menu-item-added menu-item-settings-expanded', function(e){
+            repositionSplitDropdown(e.target);
+        });
+    });
+    JS;
+
+    wp_add_inline_script('nav-menu', $js);
 });

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -280,6 +280,9 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 			$id = apply_filters( 'nav_menu_item_id', 'menu-item-'. $item->ID, $item, $args, $depth );
 			$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
 
+			$has_children = in_array( 'menu-item-has-children', $classes, true );
+			$split_enabled = ( get_post_meta( $item->ID, '_menu_item_split_dropdown', true ) === '1' );
+
 			// New
 			if ($depth === 0) {
 				$output .= $indent . '<li' . $id . $class_names .'>';
@@ -299,7 +302,7 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 				$atts['class'] = 'nav-link';
 			}
 
-			if ( $depth === 0 && in_array( 'menu-item-has-children', $classes ) && get_post_meta( $item->ID, '_menu_item_split_dropdown', true ) !== '1' ) {
+			if ( $depth === 0 && $has_children && ! $split_enabled ) {
 				$atts['class']       .= ' dropdown-toggle';
 				$atts['data-toggle']  = 'dropdown';
 			}
@@ -354,7 +357,7 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 			}
 			*/
 			//
-			if( $depth === 0 && in_array( 'menu-item-has-children', $classes ) && get_post_meta( $item->ID, '_menu_item_split_dropdown', true ) === '1' )
+			if( $depth === 0 && $has_children && $split_enabled )
 			{
 				$item_output .= '<a' . $attributes. '>';
 				/** This filter is documented in wp-includes/post-template.php */

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -299,7 +299,7 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 				$atts['class'] = 'nav-link';
 			}
 
-			if ($depth === 0 && in_array('menu-item-has-children', $classes) && get_post_meta($item->ID, '_menu_item_split_dropdown', true) !== '1') {
+			if ( $depth === 0 && in_array( 'menu-item-has-children', $classes ) && get_post_meta( $item->ID, '_menu_item_split_dropdown', true ) !== '1' ) {
 				$atts['class']       .= ' dropdown-toggle';
 				$atts['data-toggle']  = 'dropdown';
 			}
@@ -354,9 +354,10 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 			}
 			*/
 			//
-			if($depth === 0 && in_array('menu-item-has-children', $classes) && get_post_meta($item->ID, '_menu_item_split_dropdown', true) === '1')
+			if( $depth === 0 && in_array( 'menu-item-has-children', $classes ) && get_post_meta( $item->ID, '_menu_item_split_dropdown', true ) === '1' )
 			{
 				$item_output .= '<a' . $attributes. '>';
+				/** This filter is documented in wp-includes/post-template.php */
 				$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
 				$item_output .= '</a>';
 				
@@ -436,8 +437,8 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
  * @param array  $args         An array of {@see wp_nav_menu()} arguments.
  * @return void
  */
-add_action('wp_nav_menu_item_custom_fields', function( $menu_item_id, $item, $depth, $args) {
-	if ((int) $depth !== 0){ return; }
+add_action( 'wp_nav_menu_item_custom_fields', function( $menu_item_id, $item, $depth, $args ) {
+	if ( (int) $depth !== 0 ) { return; }
 
 	$value = get_post_meta( $menu_item_id, '_menu_item_split_dropdown', true );
 	?>
@@ -463,12 +464,12 @@ add_action('wp_nav_menu_item_custom_fields', function( $menu_item_id, $item, $de
  * @param array  $args          An array of {@see wp_nav_menu()} arguments.
  * @return void
  */
-add_action('wp_update_nav_menu_item', function( $menu_id, $menu_item_db_id, $args) {
-   $is_set = isset($_POST['menu-item-split-dropdown'][ $menu_item_db_id ]) ? '1' : '';
-   if ($is_set !== '') {
-       update_post_meta($menu_item_db_id, '_menu_item_split_dropdown', '1');
+add_action( 'wp_update_nav_menu_item', function( $menu_id, $menu_item_db_id, $args ) {
+   $is_set = isset( $_POST['menu-item-split-dropdown'][ $menu_item_db_id ] ) ? '1' : '';
+   if ( $is_set !== '' ) {
+       update_post_meta( $menu_item_db_id, '_menu_item_split_dropdown', '1' );
    } else {
-       delete_post_meta($menu_item_db_id, '_menu_item_split_dropdown');
+       delete_post_meta( $menu_item_db_id, '_menu_item_split_dropdown' );
    }
 }, 10, 3 );
 
@@ -485,8 +486,18 @@ add_filter( 'wp_setup_nav_menu_item', function( $item ) {
    return $item;
 });
 
-add_action('admin_enqueue_scripts', function( $hook ) {
-    if ($hook !== 'nav-menus.php'){ return; }
+
+/*
+ * Ensures that the custom "Split dropdown" field is visually aligned
+ * with the existing "Open link in a new tab" field.
+ * @author Jhon Tabio
+ * @since unknown
+ *
+ * @param string $hook Current admin page hook suffix.
+ * @return void
+ */
+add_action( 'admin_enqueue_scripts', function( $hook ) {
+    if ( $hook !== 'nav-menus.php' ){ return; }
 
     $css = <<<CSS
     .menu-item-settings .field-link-target,
@@ -499,7 +510,7 @@ add_action('admin_enqueue_scripts', function( $hook ) {
     }
     CSS;
 
-    wp_add_inline_style('common', $css);
+    wp_add_inline_style( 'common', $css );
 
     $js = <<<JS
     jQuery(function($){
@@ -523,5 +534,5 @@ add_action('admin_enqueue_scripts', function( $hook ) {
     });
     JS;
 
-    wp_add_inline_script('nav-menu', $js);
+    wp_add_inline_script( 'nav-menu', $js );
 });

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -299,7 +299,7 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 				$atts['class'] = 'nav-link';
 			}
 
-			if ($depth === 0 && in_array('menu-item-has-children', $classes)) {
+			if ($depth === 0 && in_array('menu-item-has-children', $classes) && get_post_meta($item->ID, '_menu_item_split_dropdown', true) !== '1') {
 				$atts['class']       .= ' dropdown-toggle';
 				$atts['data-toggle']  = 'dropdown';
 			}
@@ -354,10 +354,42 @@ if ( !class_exists( 'bs4Navwalker' ) ) {
 			}
 			*/
 			//
-			$item_output .= '<a'. $attributes .'>';
-			/** This filter is documented in wp-includes/post-template.php */
-			$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
-			$item_output .= '</a>';
+			if($depth === 0 && in_array('menu-item-has-children', $classes) && get_post_meta($item->ID, '_menu_item_split_dropdown', true) === '1')
+			{
+				$item_output .= '<div class="btn-group">';
+
+				$item_output .= '<a' . $attributes. '>';
+				$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
+				$item_output .= '</a>';
+				
+				// Toggle link (split control)
+				$toggle_atts = array(
+				    'href'           => '#',
+				    'class'          => 'nav-link dropdown-toggle dropdown-toggle-split',
+				    'data-toggle'    => 'dropdown',
+				    'aria-haspopup'  => 'true',
+				    'aria-expanded'  => 'false',
+				    'role'           => 'button'
+				);
+
+				$toggle_attr_str = '';
+				foreach ( $toggle_atts as $attr => $value ) {
+				    $toggle_attr_str .= ' ' . $attr . '="' . esc_attr( $value ) . '"';
+				}
+
+				$item_output .= '<a' . $toggle_attr_str . '></a>';
+				
+				$item_output .= '</div>';
+	
+			}
+			else
+			{
+				$item_output .= '<a'. $attributes .'>';
+				/** This filter is documented in wp-includes/post-template.php */
+				$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
+				$item_output .= '</a>';
+			}
+
 			$item_output .= $args->after;
 
 			/**


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-WordPress-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-WordPress-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->

This PR introduces full support for *split dropdown* navigation items in the UCF-WordPress-Theme.  
The update modifies the theme’s navigation walker to output the correct markup required by the Athena Framework’s split dropdown component.  

Changes include:
- Updating the nav walker to generate Athena-compliant split dropdown markup  
- Rendering a clickable parent link along with an independent dropdown toggle  
- Ensuring submenus expand / collapse correctly on click / tap  
- Maintaining backward compatibility with existing menu structures
- Add a new split checkbox within the admin menu configuration

The implementation uses the *existing Athena component* without custom markup, ensuring consistency across UCF digital properties.


**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change solves a long-standing limitation in the theme where a parent navigation item with a dropdown could not function both as a direct link *and* as a dropdown toggle.  

Without split dropdown support:
- Parent links become effectively unusable  
- Nested navigation becomes unreachable in certain layouts  
- The theme deviates from Athena’s supported navigation patterns  

This PR implements split dropdown support using the same component Athena already provides.

Fixes: #161 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->

Testing was performed in the following ways:

- Implemented the updated nav walker within a WordPress environment running the UCF-WordPress-Theme  
- Created a navigation menu with mixed parent links, dropdowns, and split dropdowns  
- Verified that:  
  - Parent links remain clickable  
  - Toggle arrows correctly expand/collapse submenus  

Tested with desktop and mobile breakpoints  

No regressions were observed with existing dropdown behavior.


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
